### PR TITLE
Add missing Applicative instance for NEList

### DIFF
--- a/Opaleye/Internal/NEList.hs
+++ b/Opaleye/Internal/NEList.hs
@@ -1,5 +1,8 @@
 module Opaleye.Internal.NEList where
 
+import Control.Applicative (Applicative(..))
+
+
 data NEList a = NEList a [a] deriving Show
 
 singleton :: a -> NEList a
@@ -13,6 +16,11 @@ neCat (NEList a as) bs = NEList a (as ++ toList bs)
 
 instance Functor NEList where
   fmap f (NEList a as) = NEList (f a) (fmap f as)
+
+instance Applicative NEList where
+  pure = flip NEList []
+  f <*> x = let (y:ys) = toList f <*> toList x
+            in NEList y ys
 
 instance Monad NEList where
   return = flip NEList []


### PR DESCRIPTION
The instance behaves just like the one for `[a]`.

The lack of this instance definition triggers a compilation warning in GHC 7.8.3.

It's worth pointing out that the `semigroups` package, on which `opaleye` already depends indirectly, exports a “non-empty list” at [`Data.List.NonEmpty`](http://hackage.haskell.org/package/semigroups-0.15.4/docs/Data-List-NonEmpty.html). Unless there is a concrete need why `opaleye` needs to introduce `NEList` (there doesn't seem to be one), I suggest we use `Data.List.NonEmpty` from `semigroups` instead. 
