### PR TITLE
Support for citext

### DIFF
--- a/opaleye.cabal
+++ b/opaleye.cabal
@@ -23,9 +23,10 @@ library
   hs-source-dirs: src
   build-depends:
       base                >= 4       && < 5
+    , case-insensitive    >= 1.2     && < 1.3
     , contravariant       >= 0.4.4   && < 1.3
     , old-locale          >= 1.0     && < 1.1
-    , postgresql-simple   >= 0.3     && < 0.5
+    , postgresql-simple   >= 0.4.8.0 && < 0.5
     , pretty              >= 1.1.1.0 && < 1.2
     , product-profunctors >= 0.5     && < 0.7
     , profunctors         >= 4.0     && < 4.4

--- a/src/Opaleye/Internal/RunQuery.hs
+++ b/src/Opaleye/Internal/RunQuery.hs
@@ -21,6 +21,7 @@ import qualified Data.Profunctor.Product as PP
 import           Data.Profunctor.Product (empty, (***!))
 import qualified Data.Profunctor.Product.Default as D
 
+import qualified Data.CaseInsensitive as CI
 import qualified Data.Text as ST
 import qualified Data.Text.Lazy as LT
 import qualified Data.Time as Time
@@ -103,6 +104,14 @@ instance QueryRunnerColumnDefault T.PGTimestamp Time.LocalTime where
 
 instance QueryRunnerColumnDefault T.PGTime Time.TimeOfDay where
   queryRunnerColumnDefault = fieldQueryRunnerColumn
+
+instance QueryRunnerColumnDefault T.PGCitext (CI.CI ST.Text) where
+  queryRunnerColumnDefault = fieldQueryRunnerColumn
+
+instance QueryRunnerColumnDefault T.PGCitext (CI.CI LT.Text) where
+  queryRunnerColumnDefault = fieldQueryRunnerColumn
+
+-- No CI String instance since postgresql-simple doesn't define FromField (CI String)
 
 -- }
 

--- a/src/Opaleye/PGTypes.hs
+++ b/src/Opaleye/PGTypes.hs
@@ -7,6 +7,7 @@ import qualified Opaleye.Internal.Column as C
 
 import qualified Opaleye.Internal.HaskellDB.PrimQuery as HPQ
 
+import qualified Data.CaseInsensitive as CI
 import qualified Data.Text as SText
 import qualified Data.Text.Lazy as LText
 import qualified Data.Time as Time
@@ -28,6 +29,7 @@ data PGTime
 data PGTimestamp
 data PGTimestamptz
 data PGUuid
+data PGCitext
 
 instance C.PGNum PGFloat8 where
   pgFromInteger = pgDouble . fromInteger
@@ -91,3 +93,12 @@ pgTimeOfDay = unsafePgFormatTime "time" "'%T'"
 
 -- "We recommend not using the type time with time zone"
 -- http://www.postgresql.org/docs/8.3/static/datatype-datetime.html
+
+
+pgCiStrictText :: CI.CI SText.Text -> Column PGCitext
+pgCiStrictText = literalColumn . HPQ.StringLit . SText.unpack . CI.original
+
+pgCiLazyText :: CI.CI LText.Text -> Column PGCitext
+pgCiLazyText = literalColumn . HPQ.StringLit . LText.unpack . CI.original
+
+-- No CI String instance since postgresql-simple doesn't define FromField (CI String)


### PR DESCRIPTION
This is less intrusive now, postgresql-simple added CI instances for Text. Since case-insensitive has bytestring instances that assume encoding (and latin1 at that) Leon decided to not provide a polymorphic instance.

It's a free dependency. It does require the latest version of postgresql-simple, if we care about backwards compatibility I can CPP it.

And as previously discussed, citext isn't necessarily available on all postgres installs, but it is a standard extension.
