### PR TITLE
Remove extra output value in SQL for join

### DIFF
--- a/Doc/Tutorial/TutorialBasic.lhs
+++ b/Doc/Tutorial/TutorialBasic.lhs
@@ -346,7 +346,6 @@ Idealized SQL:
 SELECT name0,
        age0,
        address0,
-       name1,
        birthday1
 FROM (SELECT name as name0,
              age as age0,


### PR DESCRIPTION
The idealized SQL for the join example is wrong as the query should be returning four values. Just removing the extras here.