### PR TITLE
Add json types

### DIFF
--- a/opaleye.cabal
+++ b/opaleye.cabal
@@ -64,6 +64,7 @@ library
                    Opaleye.Internal.Order,
                    Opaleye.Internal.Optimize,
                    Opaleye.Internal.PackMap,
+                   Opaleye.Internal.PGTypes,
                    Opaleye.Internal.PrimQuery,
                    Opaleye.Internal.Print,
                    Opaleye.Internal.QueryArr,

--- a/src/Opaleye/Internal/PGTypes.hs
+++ b/src/Opaleye/Internal/PGTypes.hs
@@ -1,0 +1,24 @@
+module Opaleye.Internal.PGTypes where
+
+import           Opaleye.Internal.Column (Column(Column))
+import qualified Opaleye.Internal.HaskellDB.PrimQuery as HPQ
+
+import qualified Data.Text as SText
+import qualified Data.Text.Encoding as STextEncoding
+import qualified Data.Text.Lazy as LText
+import qualified Data.Text.Lazy.Encoding as LTextEncoding
+import qualified Data.ByteString as SByteString
+import qualified Data.ByteString.Lazy as LByteString
+import qualified Data.Time as Time
+import qualified Data.Time.Locale.Compat as Locale
+
+unsafePgFormatTime :: Time.FormatTime t => HPQ.Name -> String -> t -> Column c
+unsafePgFormatTime typeName formatString = castToType typeName . format
+  where format = Time.formatTime Locale.defaultTimeLocale formatString
+
+literalColumn :: HPQ.Literal -> Column a
+literalColumn = Column . HPQ.ConstExpr
+
+castToType :: HPQ.Name -> String -> Column c
+castToType typeName =
+    Column . HPQ.CastExpr typeName . HPQ.ConstExpr . HPQ.OtherLit

--- a/src/Opaleye/Internal/PGTypes.hs
+++ b/src/Opaleye/Internal/PGTypes.hs
@@ -22,3 +22,9 @@ literalColumn = Column . HPQ.ConstExpr
 castToType :: HPQ.Name -> String -> Column c
 castToType typeName =
     Column . HPQ.CastExpr typeName . HPQ.ConstExpr . HPQ.OtherLit
+
+strictDecodeUtf8 :: SByteString.ByteString -> String
+strictDecodeUtf8 = SText.unpack . STextEncoding.decodeUtf8
+
+lazyDecodeUtf8 :: LByteString.ByteString -> String
+lazyDecodeUtf8 = LText.unpack . LTextEncoding.decodeUtf8

--- a/src/Opaleye/Internal/RunQuery.hs
+++ b/src/Opaleye/Internal/RunQuery.hs
@@ -140,6 +140,12 @@ instance QueryRunnerColumnDefault T.PGCitext (CI.CI ST.Text) where
 instance QueryRunnerColumnDefault T.PGCitext (CI.CI LT.Text) where
   queryRunnerColumnDefault = fieldQueryRunnerColumn
 
+instance QueryRunnerColumnDefault T.PGJson String where
+  queryRunnerColumnDefault = fieldQueryRunnerColumn
+
+instance QueryRunnerColumnDefault T.PGJsonb String where
+  queryRunnerColumnDefault = fieldQueryRunnerColumn
+
 -- No CI String instance since postgresql-simple doesn't define FromField (CI String)
 
 arrayColumn :: Column (T.PGArray a) -> Column a

--- a/src/Opaleye/PGTypes.hs
+++ b/src/Opaleye/PGTypes.hs
@@ -1,9 +1,10 @@
 {-# LANGUAGE EmptyDataDecls #-}
 
-module Opaleye.PGTypes where
+module Opaleye.PGTypes (module Opaleye.PGTypes) where
 
-import           Opaleye.Internal.Column (Column(Column))
+import           Opaleye.Internal.Column (Column)
 import qualified Opaleye.Internal.Column as C
+import qualified Opaleye.Internal.PGTypes as IPT
 
 import qualified Opaleye.Internal.HaskellDB.PrimQuery as HPQ
 
@@ -13,7 +14,6 @@ import qualified Data.Text.Lazy as LText
 import qualified Data.ByteString as SByteString
 import qualified Data.ByteString.Lazy as LByteString
 import qualified Data.Time as Time
-import qualified Data.Time.Locale.Compat as Locale
 import qualified Data.UUID as UUID
 
 import           Data.Int (Int64)
@@ -48,67 +48,67 @@ instance C.PGFractional PGFloat8 where
   pgFromRational = pgDouble . fromRational
 
 literalColumn :: HPQ.Literal -> Column a
-literalColumn = Column . HPQ.ConstExpr
+literalColumn = IPT.literalColumn
+{-# WARNING literalColumn
+    "'literalColumn' has been moved to Opaleye.Internal.PGTypes"
+  #-}
 
 pgString :: String -> Column PGText
-pgString = literalColumn . HPQ.StringLit
+pgString = IPT.literalColumn . HPQ.StringLit
 
 pgLazyByteString :: LByteString.ByteString -> Column PGBytea
-pgLazyByteString = literalColumn . HPQ.ByteStringLit . LByteString.toStrict
+pgLazyByteString = IPT.literalColumn . HPQ.ByteStringLit . LByteString.toStrict
 
 pgStrictByteString :: SByteString.ByteString -> Column PGBytea
-pgStrictByteString = literalColumn . HPQ.ByteStringLit
+pgStrictByteString = IPT.literalColumn . HPQ.ByteStringLit
 
 pgStrictText :: SText.Text -> Column PGText
-pgStrictText = literalColumn . HPQ.StringLit . SText.unpack
+pgStrictText = IPT.literalColumn . HPQ.StringLit . SText.unpack
 
 pgLazyText :: LText.Text -> Column PGText
-pgLazyText = literalColumn . HPQ.StringLit . LText.unpack
+pgLazyText = IPT.literalColumn . HPQ.StringLit . LText.unpack
 
 pgInt4 :: Int -> Column PGInt4
-pgInt4 = literalColumn . HPQ.IntegerLit . fromIntegral
+pgInt4 = IPT.literalColumn . HPQ.IntegerLit . fromIntegral
 
 pgInt8 :: Int64 -> Column PGInt8
-pgInt8 = literalColumn . HPQ.IntegerLit . fromIntegral
+pgInt8 = IPT.literalColumn . HPQ.IntegerLit . fromIntegral
 
 pgDouble :: Double -> Column PGFloat8
-pgDouble = literalColumn . HPQ.DoubleLit
+pgDouble = IPT.literalColumn . HPQ.DoubleLit
 
 pgBool :: Bool -> Column PGBool
-pgBool = literalColumn . HPQ.BoolLit
+pgBool = IPT.literalColumn . HPQ.BoolLit
 
 pgUUID :: UUID.UUID -> Column PGUuid
 pgUUID = C.unsafeCoerce . pgString . UUID.toString
 
--- Internal use only!
 unsafePgFormatTime :: Time.FormatTime t => HPQ.Name -> String -> t -> Column c
-unsafePgFormatTime typeName formatString = Column
-                                     . HPQ.CastExpr typeName
-                                     . HPQ.ConstExpr
-                                     . HPQ.OtherLit
-                                     . format
-  where format = Time.formatTime Locale.defaultTimeLocale formatString
+unsafePgFormatTime = IPT.unsafePgFormatTime
+{-# WARNING unsafePgFormatTime
+    "'unsafePgFormatTime' has been moved to Opaleye.Internal.PGTypes"
+  #-}
 
 pgDay :: Time.Day -> Column PGDate
-pgDay = unsafePgFormatTime "date" "'%F'"
+pgDay = IPT.unsafePgFormatTime "date" "'%F'"
 
 pgUTCTime :: Time.UTCTime -> Column PGTimestamptz
-pgUTCTime = unsafePgFormatTime "timestamptz" "'%FT%TZ'"
+pgUTCTime = IPT.unsafePgFormatTime "timestamptz" "'%FT%TZ'"
 
 pgLocalTime :: Time.LocalTime -> Column PGTimestamp
-pgLocalTime = unsafePgFormatTime "timestamp" "'%FT%T'"
+pgLocalTime = IPT.unsafePgFormatTime "timestamp" "'%FT%T'"
 
 pgTimeOfDay :: Time.TimeOfDay -> Column PGTime
-pgTimeOfDay = unsafePgFormatTime "time" "'%T'"
+pgTimeOfDay = IPT.unsafePgFormatTime "time" "'%T'"
 
 -- "We recommend not using the type time with time zone"
 -- http://www.postgresql.org/docs/8.3/static/datatype-datetime.html
 
 
 pgCiStrictText :: CI.CI SText.Text -> Column PGCitext
-pgCiStrictText = literalColumn . HPQ.StringLit . SText.unpack . CI.original
+pgCiStrictText = IPT.literalColumn . HPQ.StringLit . SText.unpack . CI.original
 
 pgCiLazyText :: CI.CI LText.Text -> Column PGCitext
-pgCiLazyText = literalColumn . HPQ.StringLit . LText.unpack . CI.original
+pgCiLazyText = IPT.literalColumn . HPQ.StringLit . LText.unpack . CI.original
 
 -- No CI String instance since postgresql-simple doesn't define FromField (CI String)

--- a/src/Opaleye/PGTypes.hs
+++ b/src/Opaleye/PGTypes.hs
@@ -34,6 +34,8 @@ data PGUuid
 data PGCitext
 data PGArray a
 data PGBytea
+data PGJson
+data PGJsonb
 
 instance C.PGNum PGFloat8 where
   pgFromInteger = pgDouble . fromInteger
@@ -112,3 +114,23 @@ pgCiLazyText :: CI.CI LText.Text -> Column PGCitext
 pgCiLazyText = IPT.literalColumn . HPQ.StringLit . LText.unpack . CI.original
 
 -- No CI String instance since postgresql-simple doesn't define FromField (CI String)
+
+-- The json data type was introduced in PostgreSQL version 9.2
+pgJSON :: String -> Column PGJson
+pgJSON = IPT.castToType "json"
+
+pgStrictJSON :: SByteString.ByteString -> Column PGJson
+pgStrictJSON = pgJSON . IPT.strictDecodeUtf8
+
+pgLazyJSON :: LByteString.ByteString -> Column PGJson
+pgLazyJSON = pgJSON . IPT.lazyDecodeUtf8
+
+-- The jsonb data type was introduced in PostgreSQL version 9.4
+pgJSONB :: String -> Column PGJsonb
+pgJSONB = IPT.castToType "jsonb"
+
+pgStrictJSONB :: SByteString.ByteString -> Column PGJsonb
+pgStrictJSONB = pgJSONB . IPT.strictDecodeUtf8
+
+pgLazyJSONB :: LByteString.ByteString -> Column PGJsonb
+pgLazyJSONB = pgJSONB . IPT.lazyDecodeUtf8


### PR DESCRIPTION
The addition of these types intentionally does not address a number of issues:

* A mechanism, if there should be any, for indicating that these types are not available in all currently supported versions of PostgreSQL (currently, comments in the code indicate the applicable versions). A mechanism for indicating the versions of PostgreSQL to which various types, etc. apply is outside the scope of this change.

* The streaming of large documents to the database. It's not clear to me how this would work or should be done.

* Automatic decoding of types in a JSON serialization type class by the `pg*JSON[B]` column generation functions. This would require a dependency on a JSON serialization package (`aeson`, `json`, etc.), and I for one prefer to keep package dependencies to a minimum, especially in situations like this, where only a small subset of the depending package's consumers will utilize the functionality requiring the dependency.
