### PR TITLE
I14

### DIFF
--- a/src/Opaleye/Aggregate.hs
+++ b/src/Opaleye/Aggregate.hs
@@ -39,11 +39,11 @@ avg :: Aggregator (C.Column T.PGFloat8) (C.Column T.PGFloat8)
 avg = A.makeAggr HPQ.AggrAvg
 
 -- | Maximum of a group
-max :: Aggregator (C.Column a) (C.Column a)
+max :: (T.ComparableColumn a) => Aggregator (C.Column a) (C.Column a)
 max = A.makeAggr HPQ.AggrMax
 
 -- | Maximum of a group
-min :: Aggregator (C.Column a) (C.Column a)
+min :: (T.ComparableColumn a) => Aggregator (C.Column a) (C.Column a)
 min = A.makeAggr HPQ.AggrMin
 
 boolOr :: Aggregator (C.Column T.PGBool) (C.Column T.PGBool)

--- a/src/Opaleye/Operators.hs
+++ b/src/Opaleye/Operators.hs
@@ -24,23 +24,23 @@ infix 4 .==
 (.==) = unsafeEq
 
 infix 4 ./=
-(./=) :: Column a -> Column a -> Column T.PGBool
+(./=) :: (T.ComparableColumn a) => Column a -> Column a -> Column T.PGBool
 (./=) = C.binOp HPQ.OpNotEq
 
 infix 4 .>
-(.>) :: Column a -> Column a -> Column T.PGBool
+(.>) :: (T.ComparableColumn a) => Column a -> Column a -> Column T.PGBool
 (.>) = unsafeGt
 
 infix 4 .<
-(.<) :: Column a -> Column a -> Column T.PGBool
+(.<) :: (T.ComparableColumn a) => Column a -> Column a -> Column T.PGBool
 (.<) = C.binOp HPQ.OpLt
 
 infix 4 .<=
-(.<=) :: Column a -> Column a -> Column T.PGBool
+(.<=) :: (T.ComparableColumn a) => Column a -> Column a -> Column T.PGBool
 (.<=) = C.binOp HPQ.OpLtEq
 
 infix 4 .>=
-(.>=) :: Column a -> Column a -> Column T.PGBool
+(.>=) :: (T.ComparableColumn a) => Column a -> Column a -> Column T.PGBool
 (.>=) = C.binOp HPQ.OpGtEq
 
 case_ :: [(Column T.PGBool, Column a)] -> Column a -> Column a

--- a/src/Opaleye/PGTypes.hs
+++ b/src/Opaleye/PGTypes.hs
@@ -49,6 +49,22 @@ instance C.PGNum PGInt8 where
 instance C.PGFractional PGFloat8 where
   pgFromRational = pgDouble . fromRational
 
+-- | Such a column supports the min, max aggregations
+class ComparableColumn a
+
+instance ComparableColumn PGDate
+instance ComparableColumn PGFloat8
+instance ComparableColumn PGFloat4
+instance ComparableColumn PGInt8
+instance ComparableColumn PGInt4
+instance ComparableColumn PGInt2
+instance ComparableColumn PGNumeric
+instance ComparableColumn PGText
+instance ComparableColumn PGTime
+instance ComparableColumn PGTimestamptz
+instance ComparableColumn PGTimestamp
+instance ComparableColumn PGCitext
+
 literalColumn :: HPQ.Literal -> Column a
 literalColumn = IPT.literalColumn
 {-# WARNING literalColumn


### PR DESCRIPTION
Implementation of #14 

I actually tried in the `psql` 9.3.6, if the aggregation doesn't result exception for the types that have the `ColumnComparable` typeclass.

I'd like to cover the other types if this is ok, the single-dimensional array of ints works, there might be rule that if ColumnComparable a => ColumnComparable (DBArray a), but that would need some testing.  