### PR TITLE
Wrap table names in double quotes

### DIFF
--- a/src/Opaleye/Internal/HaskellDB/Sql.hs
+++ b/src/Opaleye/Internal/HaskellDB/Sql.hs
@@ -11,7 +11,7 @@ import qualified Data.List.NonEmpty as NEL
 -- * SQL data type
 -----------------------------------------------------------
 
-type SqlTable = String
+newtype SqlTable = SqlTable String deriving Show
 
 newtype SqlColumn = SqlColumn String deriving Show
 

--- a/src/Opaleye/Internal/HaskellDB/Sql/Default.hs
+++ b/src/Opaleye/Internal/HaskellDB/Sql/Default.hs
@@ -57,7 +57,7 @@ defaultSqlUpdate :: SqlGenerator
                  -> Assoc -- ^ Update the data with this.
                  -> SqlUpdate
 defaultSqlUpdate gen name criteria assigns
-        = SqlUpdate name (toSqlAssoc gen assigns) (map (sqlExpr gen) criteria)
+        = SqlUpdate (SqlTable name) (toSqlAssoc gen assigns) (map (sqlExpr gen) criteria) 
 
 
 defaultSqlInsert :: SqlGenerator
@@ -65,15 +65,15 @@ defaultSqlInsert :: SqlGenerator
                  -> [Attribute]
                  -> NEL.NonEmpty [PrimExpr]
                  -> SqlInsert
-defaultSqlInsert gen table attrs exprs =
-  SqlInsert table (map toSqlColumn attrs) ((fmap . map) (sqlExpr gen) exprs)
+defaultSqlInsert gen name attrs exprs =
+  SqlInsert (SqlTable name) (map toSqlColumn attrs) ((fmap . map) (sqlExpr gen) exprs)
 
 defaultSqlDelete :: SqlGenerator
                  -> TableName -- ^ Name of the table
                  -> [PrimExpr] -- ^ Criteria which must all be true for a row
                                --   to be deleted.
                  -> SqlDelete
-defaultSqlDelete gen name criteria = SqlDelete name (map (sqlExpr gen) criteria)
+defaultSqlDelete gen name criteria = SqlDelete (SqlTable name) (map (sqlExpr gen) criteria)
 
 
 defaultSqlExpr :: SqlGenerator -> PrimExpr -> SqlExpr

--- a/src/Opaleye/Internal/HaskellDB/Sql/Print.hs
+++ b/src/Opaleye/Internal/HaskellDB/Sql/Print.hs
@@ -10,6 +10,7 @@ module Opaleye.Internal.HaskellDB.Sql.Print (
                                      ppWhere,
                                      ppGroupBy,
                                      ppOrderBy,
+                                     ppTable,
                                      ppAs,
                                      commaV,
                                      commaH
@@ -17,7 +18,7 @@ module Opaleye.Internal.HaskellDB.Sql.Print (
 
 import Opaleye.Internal.HaskellDB.Sql (SqlColumn(..), SqlDelete(..),
                                SqlExpr(..), SqlOrder(..), SqlInsert(..),
-                               SqlUpdate(..))
+                               SqlUpdate(..), SqlTable(..))
 import qualified Opaleye.Internal.HaskellDB.Sql as Sql
 
 import Data.List (intersperse)
@@ -64,8 +65,8 @@ ppAs alias expr    | null alias    = expr
 
 
 ppUpdate :: SqlUpdate -> Doc
-ppUpdate (SqlUpdate name assigns criteria)
-        = text "UPDATE" <+> text name
+ppUpdate (SqlUpdate table assigns criteria)
+        = text "UPDATE" <+> ppTable table
         $$ text "SET" <+> commaV ppAssign assigns
         $$ ppWhere criteria
     where
@@ -73,13 +74,13 @@ ppUpdate (SqlUpdate name assigns criteria)
 
 
 ppDelete :: SqlDelete -> Doc
-ppDelete (SqlDelete name criteria) =
-    text "DELETE FROM" <+> text name $$ ppWhere criteria
+ppDelete (SqlDelete table criteria) =
+    text "DELETE FROM" <+> ppTable table $$ ppWhere criteria
 
 
 ppInsert :: SqlInsert -> Doc
 ppInsert (SqlInsert table names values)
-    = text "INSERT INTO" <+> text table
+    = text "INSERT INTO" <+> ppTable table
       <+> parens (commaV ppColumn names)
       $$ text "VALUES" <+> commaV (\v -> parens (commaV ppSqlExpr v))
                                   (NEL.toList values)
@@ -92,6 +93,8 @@ ppInsert (SqlInsert table names values)
 ppColumn :: SqlColumn -> Doc
 ppColumn (SqlColumn s) = doubleQuotes (text s)
 
+ppTable :: SqlTable -> Doc
+ppTable (SqlTable s) = doubleQuotes (text s)
 
 ppSqlExpr :: SqlExpr -> Doc
 ppSqlExpr expr =

--- a/src/Opaleye/Internal/Print.hs
+++ b/src/Opaleye/Internal/Print.hs
@@ -15,9 +15,11 @@ import qualified Opaleye.Internal.HaskellDB.Sql.Print as HPrint
 import           Text.PrettyPrint.HughesPJ (Doc, ($$), (<+>), text, empty,
                                             parens)
 
+type TableAlias = String
+
 ppSql :: Select -> Doc
 ppSql (SelectFrom s) = ppSelectFrom s
-ppSql (Table name) = text name
+ppSql (Table table) = HPrint.ppTable table
 ppSql (SelectJoin j) = ppSelectJoin j
 ppSql (SelectValues v) = ppSelectValues v
 ppSql (SelectBinary v) = ppSelectBinary v
@@ -71,13 +73,13 @@ ppTables :: [Select] -> Doc
 ppTables [] = empty
 ppTables ts = text "FROM" <+> HPrint.commaV ppTable (zipWith tableAlias [1..] ts)
 
-tableAlias :: Int -> Select -> (HSql.SqlTable, Select)
+tableAlias :: Int -> Select -> (TableAlias, Select)
 tableAlias i select = ("T" ++ show i, select)
 
 -- TODO: duplication with ppSql
-ppTable :: (HSql.SqlTable, Select) -> Doc
+ppTable :: (TableAlias, Select) -> Doc
 ppTable (alias, select) = case select of
-  Table name -> HPrint.ppAs alias (text name)
+  Table table -> HPrint.ppAs alias (HPrint.ppTable table)
   SelectFrom selectFrom -> HPrint.ppAs alias (parens (ppSelectFrom selectFrom))
   SelectJoin slj -> HPrint.ppAs alias (parens (ppSelectJoin slj))
   SelectValues slv -> HPrint.ppAs alias (parens (ppSelectValues slv))

--- a/src/Opaleye/Internal/Sql.hs
+++ b/src/Opaleye/Internal/Sql.hs
@@ -77,7 +77,7 @@ unit = SelectFrom newSelect { attrs  = [(HSql.ConstSqlExpr "0", Nothing)] }
 baseTable :: String -> [(Symbol, HPQ.PrimExpr)] -> Select
 baseTable name columns = SelectFrom $
     newSelect { attrs = map sqlBinding columns
-              , tables = [Table name] }
+              , tables = [Table (HSql.SqlTable name)] }
 
 product :: NEL.NonEmpty Select -> [HPQ.PrimExpr] -> Select
 product ss pes = SelectFrom $


### PR DESCRIPTION
This adds support for tables whose names include capital letters.