### PR TITLE
Clean white space related issues.

### DIFF
--- a/Doc/Tutorial/TutorialAdvanced.lhs
+++ b/Doc/Tutorial/TutorialAdvanced.lhs
@@ -47,7 +47,7 @@ people's names along with the age of their children.
 > rangeOfChildrensAges = aggregate (p2 (A.groupBy, range)) (queryTable personTable)
 
 
-TutorialAdvanced> printSql rangeOfChildrensAges 
+TutorialAdvanced> printSql rangeOfChildrensAges
 SELECT result0_2 as result1,
        (result1_2) - (result2_2) as result2
 FROM (SELECT *

--- a/src/Opaleye/Internal/HaskellDB/PrimQuery.hs
+++ b/src/Opaleye/Internal/HaskellDB/PrimQuery.hs
@@ -21,7 +21,7 @@ data PrimExpr   = AttrExpr  Symbol
                 | UnExpr    UnOp PrimExpr
                 | AggrExpr  AggrOp PrimExpr
                 | ConstExpr Literal
-		| CaseExpr [(PrimExpr,PrimExpr)] PrimExpr
+                | CaseExpr [(PrimExpr,PrimExpr)] PrimExpr
                 | ListExpr [PrimExpr]
                 | ParamExpr (Maybe Name) PrimExpr
                 | FunExpr Name [PrimExpr]
@@ -34,18 +34,18 @@ data PrimExpr   = AttrExpr  Symbol
                 deriving (Read,Show)
 
 data Literal = NullLit
-	     | DefaultLit            -- ^ represents a default value
-	     | BoolLit Bool
-	     | StringLit String
+             | DefaultLit            -- ^ represents a default value
+             | BoolLit Bool
+             | StringLit String
              | ByteStringLit ByteString
-	     | IntegerLit Integer
-	     | DoubleLit Double
-	     | OtherLit String       -- ^ used for hacking in custom SQL
-	       deriving (Read,Show)
+             | IntegerLit Integer
+             | DoubleLit Double
+             | OtherLit String       -- ^ used for hacking in custom SQL
+               deriving (Read,Show)
 
-data BinOp      = OpEq | OpLt | OpLtEq | OpGt | OpGtEq | OpNotEq 
+data BinOp      = OpEq | OpLt | OpLtEq | OpGt | OpGtEq | OpNotEq
                 | OpAnd | OpOr
-                | OpLike | OpIn 
+                | OpLike | OpIn
                 | OpOther String
 
                 | OpCat
@@ -71,7 +71,7 @@ data AggrOp     = AggrCount | AggrSum | AggrAvg | AggrMin | AggrMax
                 | AggrOther String
                 deriving (Show,Read)
 
-data OrderExpr = OrderExpr OrderOp PrimExpr 
+data OrderExpr = OrderExpr OrderOp PrimExpr
                deriving (Show)
 
 data OrderNulls = NullsFirst | NullsLast

--- a/src/Opaleye/Internal/HaskellDB/Sql.hs
+++ b/src/Opaleye/Internal/HaskellDB/Sql.hs
@@ -36,7 +36,7 @@ data SqlExpr = ColumnSqlExpr  SqlColumn
              | FunSqlExpr     String [SqlExpr]
              | AggrFunSqlExpr String [SqlExpr] -- ^ Aggregate functions separate from normal functions.
              | ConstSqlExpr   String
-	     | CaseSqlExpr    [(SqlExpr,SqlExpr)] SqlExpr
+             | CaseSqlExpr    [(SqlExpr,SqlExpr)] SqlExpr
              | ListSqlExpr    [SqlExpr]
              | ParamSqlExpr (Maybe SqlName) SqlExpr
              | PlaceHolderSqlExpr

--- a/src/Opaleye/Internal/HaskellDB/Sql/Default.hs
+++ b/src/Opaleye/Internal/HaskellDB/Sql/Default.hs
@@ -17,7 +17,7 @@ import qualified Data.ByteString.Base16 as Base16
 import qualified Data.List.NonEmpty as NEL
 
 mkSqlGenerator :: SqlGenerator -> SqlGenerator
-mkSqlGenerator gen = SqlGenerator 
+mkSqlGenerator gen = SqlGenerator
     {
      sqlUpdate      = defaultSqlUpdate      gen,
      sqlDelete      = defaultSqlDelete      gen,
@@ -50,14 +50,14 @@ toSqlAssoc :: SqlGenerator -> Assoc -> [(SqlColumn,SqlExpr)]
 toSqlAssoc gen = map (\(attr,expr) -> (toSqlColumn attr, sqlExpr gen expr))
 
 
-defaultSqlUpdate :: SqlGenerator 
+defaultSqlUpdate :: SqlGenerator
                  -> TableName  -- ^ Name of the table to update.
-	         -> [PrimExpr] -- ^ Conditions which must all be true for a row
+                 -> [PrimExpr] -- ^ Conditions which must all be true for a row
                                --   to be updated.
                  -> Assoc -- ^ Update the data with this.
-	         -> SqlUpdate
+                 -> SqlUpdate
 defaultSqlUpdate gen name criteria assigns
-        = SqlUpdate name (toSqlAssoc gen assigns) (map (sqlExpr gen) criteria) 
+        = SqlUpdate name (toSqlAssoc gen assigns) (map (sqlExpr gen) criteria)
 
 
 defaultSqlInsert :: SqlGenerator
@@ -68,16 +68,16 @@ defaultSqlInsert :: SqlGenerator
 defaultSqlInsert gen table attrs exprs =
   SqlInsert table (map toSqlColumn attrs) ((fmap . map) (sqlExpr gen) exprs)
 
-defaultSqlDelete :: SqlGenerator 
+defaultSqlDelete :: SqlGenerator
                  -> TableName -- ^ Name of the table
-	         -> [PrimExpr] -- ^ Criteria which must all be true for a row
+                 -> [PrimExpr] -- ^ Criteria which must all be true for a row
                                --   to be deleted.
-	         -> SqlDelete
+                 -> SqlDelete
 defaultSqlDelete gen name criteria = SqlDelete name (map (sqlExpr gen) criteria)
 
 
 defaultSqlExpr :: SqlGenerator -> PrimExpr -> SqlExpr
-defaultSqlExpr gen expr = 
+defaultSqlExpr gen expr =
     case expr of
       AttrExpr (Symbol a t) -> ColumnSqlExpr (SqlColumn (tagWith t a))
       BaseTableAttrExpr a -> ColumnSqlExpr (SqlColumn a)
@@ -116,7 +116,7 @@ defaultSqlExpr gen expr =
                               e' = sqlExpr gen e
                            in AggrFunSqlExpr op' [e']
       ConstExpr l      -> ConstSqlExpr (sqlLiteral gen l)
-      CaseExpr cs e    -> let cs' = [(sqlExpr gen c, sqlExpr gen x)| (c,x) <- cs] 
+      CaseExpr cs e    -> let cs' = [(sqlExpr gen c, sqlExpr gen x)| (c,x) <- cs]
                               e'  = sqlExpr gen e
                            in CaseSqlExpr cs' e'
       ListExpr es      -> ListSqlExpr (map (sqlExpr gen) es)
@@ -126,26 +126,26 @@ defaultSqlExpr gen expr =
       DefaultInsertExpr -> DefaultSqlExpr
 
 showBinOp :: BinOp -> String
-showBinOp  OpEq         = "=" 
-showBinOp  OpLt         = "<" 
-showBinOp  OpLtEq       = "<=" 
-showBinOp  OpGt         = ">" 
-showBinOp  OpGtEq       = ">=" 
-showBinOp  OpNotEq      = "<>" 
-showBinOp  OpAnd        = "AND"  
-showBinOp  OpOr         = "OR" 
-showBinOp  OpLike       = "LIKE" 
-showBinOp  OpIn         = "IN" 
+showBinOp  OpEq         = "="
+showBinOp  OpLt         = "<"
+showBinOp  OpLtEq       = "<="
+showBinOp  OpGt         = ">"
+showBinOp  OpGtEq       = ">="
+showBinOp  OpNotEq      = "<>"
+showBinOp  OpAnd        = "AND"
+showBinOp  OpOr         = "OR"
+showBinOp  OpLike       = "LIKE"
+showBinOp  OpIn         = "IN"
 showBinOp  (OpOther s)  = s
-showBinOp  OpCat        = "||" 
-showBinOp  OpPlus       = "+" 
-showBinOp  OpMinus      = "-" 
-showBinOp  OpMul        = "*" 
-showBinOp  OpDiv        = "/" 
-showBinOp  OpMod        = "MOD" 
-showBinOp  OpBitNot     = "~" 
-showBinOp  OpBitAnd     = "&" 
-showBinOp  OpBitOr      = "|" 
+showBinOp  OpCat        = "||"
+showBinOp  OpPlus       = "+"
+showBinOp  OpMinus      = "-"
+showBinOp  OpMul        = "*"
+showBinOp  OpDiv        = "/"
+showBinOp  OpMod        = "MOD"
+showBinOp  OpBitNot     = "~"
+showBinOp  OpBitAnd     = "&"
+showBinOp  OpBitOr      = "|"
 showBinOp  OpBitXor     = "^"
 showBinOp  OpAsg        = "="
 
@@ -165,22 +165,22 @@ sqlUnOp  (UnOpOther s) = (s, UnOpFun)
 
 
 showAggrOp :: AggrOp -> String
-showAggrOp AggrCount    = "COUNT" 
-showAggrOp AggrSum      = "SUM" 
-showAggrOp AggrAvg      = "AVG" 
-showAggrOp AggrMin      = "MIN" 
-showAggrOp AggrMax      = "MAX" 
-showAggrOp AggrStdDev   = "StdDev" 
-showAggrOp AggrStdDevP  = "StdDevP" 
-showAggrOp AggrVar      = "Var" 
-showAggrOp AggrVarP     = "VarP"                
+showAggrOp AggrCount    = "COUNT"
+showAggrOp AggrSum      = "SUM"
+showAggrOp AggrAvg      = "AVG"
+showAggrOp AggrMin      = "MIN"
+showAggrOp AggrMax      = "MAX"
+showAggrOp AggrStdDev   = "StdDev"
+showAggrOp AggrStdDevP  = "StdDevP"
+showAggrOp AggrVar      = "Var"
+showAggrOp AggrVarP     = "VarP"
 showAggrOp AggrBoolAnd  = "BOOL_AND"
 showAggrOp AggrBoolOr   = "BOOL_OR"
 showAggrOp (AggrOther s)        = s
 
 
 defaultSqlLiteral :: SqlGenerator -> Literal -> String
-defaultSqlLiteral _ l = 
+defaultSqlLiteral _ l =
     case l of
       NullLit       -> "NULL"
       DefaultLit    -> "DEFAULT"
@@ -200,7 +200,7 @@ defaultSqlQuote _ s = quote s
 -- | Quote a string and escape characters that need escaping
 --   We use Postgres "escape strings", i.e. strings prefixed
 --   with E, to ensure that escaping with backslash is valid.
-quote :: String -> String 
+quote :: String -> String
 quote s = "E'" ++ concatMap escape s ++ "'"
 
 -- | Escape characters that need escaping

--- a/src/Opaleye/Internal/HaskellDB/Sql/Print.hs
+++ b/src/Opaleye/Internal/HaskellDB/Sql/Print.hs
@@ -2,9 +2,9 @@
 --                HWT Group (c) 2003, haskelldb-users@lists.sourceforge.net
 -- License     :  BSD-style
 
-module Opaleye.Internal.HaskellDB.Sql.Print ( 
+module Opaleye.Internal.HaskellDB.Sql.Print (
                                      ppUpdate,
-                                     ppDelete, 
+                                     ppDelete,
                                      ppInsert,
                                      ppSqlExpr,
                                      ppWhere,
@@ -13,7 +13,7 @@ module Opaleye.Internal.HaskellDB.Sql.Print (
                                      ppAs,
                                      commaV,
                                      commaH
-	                            ) where
+                                    ) where
 
 import Opaleye.Internal.HaskellDB.Sql (SqlColumn(..), SqlDelete(..),
                                SqlExpr(..), SqlOrder(..), SqlInsert(..),
@@ -29,7 +29,7 @@ import Text.PrettyPrint.HughesPJ (Doc, (<+>), ($$), (<>), comma, doubleQuotes,
 
 ppWhere :: [SqlExpr] -> Doc
 ppWhere [] = empty
-ppWhere es = text "WHERE" 
+ppWhere es = text "WHERE"
              <+> hsep (intersperse (text "AND")
                        (map (parens . ppSqlExpr) es))
 
@@ -41,7 +41,7 @@ ppGroupBy es = text "GROUP BY" <+> ppGroupAttrs es
     nameOrExpr :: SqlExpr -> Doc
     nameOrExpr (ColumnSqlExpr (SqlColumn col)) = text col
     nameOrExpr expr = parens (ppSqlExpr expr)
-    
+
 ppOrderBy :: [(SqlExpr,SqlOrder)] -> Doc
 ppOrderBy [] = empty
 ppOrderBy ord = text "ORDER BY" <+> commaV ppOrd ord
@@ -59,7 +59,7 @@ ppSqlNulls x = text $ case Sql.sqlOrderNulls x of
         Sql.SqlNullsLast  -> "NULLS LAST"
 
 ppAs :: String -> Doc -> Doc
-ppAs alias expr    | null alias    = expr                               
+ppAs alias expr    | null alias    = expr
                    | otherwise     = expr <+> (hsep . map text) ["as",alias]
 
 
@@ -79,7 +79,7 @@ ppDelete (SqlDelete name criteria) =
 
 ppInsert :: SqlInsert -> Doc
 ppInsert (SqlInsert table names values)
-    = text "INSERT INTO" <+> text table 
+    = text "INSERT INTO" <+> text table
       <+> parens (commaV ppColumn names)
       $$ text "VALUES" <+> commaV (\v -> parens (commaV ppSqlExpr v))
                                   (NEL.toList values)
@@ -98,7 +98,7 @@ ppSqlExpr expr =
     case expr of
       ColumnSqlExpr c     -> ppColumn c
       ParensSqlExpr e -> parens (ppSqlExpr e)
-      BinSqlExpr op e1 e2 -> ppSqlExpr e1 <+> text op <+> ppSqlExpr e2 
+      BinSqlExpr op e1 e2 -> ppSqlExpr e1 <+> text op <+> ppSqlExpr e2
       PrefixSqlExpr op e  -> text op <+> ppSqlExpr e
       PostfixSqlExpr op e -> ppSqlExpr e <+> text op
       FunSqlExpr f es     -> text f <> parens (commaH ppSqlExpr es)
@@ -106,7 +106,7 @@ ppSqlExpr expr =
       ConstSqlExpr c      -> text c
       CaseSqlExpr cs el   -> text "CASE" <+> vcat (map ppWhen cs)
                              <+> text "ELSE" <+> ppSqlExpr el <+> text "END"
-          where ppWhen (w,t) = text "WHEN" <+> ppSqlExpr w 
+          where ppWhen (w,t) = text "WHEN" <+> ppSqlExpr w
                                <+> text "THEN" <+> ppSqlExpr t
       ListSqlExpr es      -> parens (commaH ppSqlExpr es)
       ParamSqlExpr _ v -> ppSqlExpr v

--- a/src/Opaleye/Order.hs
+++ b/src/Opaleye/Order.hs
@@ -5,7 +5,7 @@ import           Opaleye.QueryArr (Query)
 import qualified Opaleye.Internal.QueryArr as Q
 import qualified Opaleye.Internal.Order as O
 import qualified Opaleye.PGTypes as T
-  
+
 import qualified Opaleye.Internal.HaskellDB.PrimQuery as HPQ
 
 {-| Order the rows of a `Query` according to the `Order`.


### PR DESCRIPTION
I was reading through some of Opaleye and noticed there was often mixes of between the use of hard tabs and spaces within the same declaration or line. There was also a lot of trailing white space. This commit just eliminates all trailing white space and replaces tabs with spaces.