### PR TITLE
Fix warnings.

### DIFF
--- a/src/Opaleye/Internal/HaskellDB/Sql/Default.hs
+++ b/src/Opaleye/Internal/HaskellDB/Sql/Default.hs
@@ -6,7 +6,6 @@ module Opaleye.Internal.HaskellDB.Sql.Default  where
 
 import Opaleye.Internal.HaskellDB.PrimQuery
 import qualified Opaleye.Internal.HaskellDB.PrimQuery as PQ
-import Opaleye.Internal.HaskellDB.PrimQuery (Assoc, PrimExpr)
 import Opaleye.Internal.HaskellDB.Sql
 import Opaleye.Internal.HaskellDB.Sql.Generate
 import qualified Opaleye.Internal.HaskellDB.Sql as Sql

--- a/src/Opaleye/Internal/RunQuery.hs
+++ b/src/Opaleye/Internal/RunQuery.hs
@@ -211,10 +211,10 @@ arrayFieldParser
           _ -> returnError Incompatible f ""
 
 fromArray :: FieldParser a -> TypeInfo -> Field -> Parser (Conversion [a])
-fromArray fieldParser typeInfo f = sequence . (parseIt <$>) <$> array delim
+fromArray fieldParser tInfo f = sequence . (parseIt <$>) <$> array delim
   where
-    delim = typdelim (typelem typeInfo)
-    fElem = f{ typeOid = typoid (typelem typeInfo) }
+    delim = typdelim (typelem tInfo)
+    fElem = f{ typeOid = typoid (typelem tInfo) }
 
     parseIt item =
         fieldParser f' $ if item' == fromString "NULL" then Nothing else Just item'


### PR DESCRIPTION
This fixes almost all warnings. The only one remaining is about 'join'
clashing with a future prelude, but that one requires some decision by
you, since renaming it will break user code, but leaving it in
probably also will.