### PR TITLE
Add runQueryFold for streaming database queries

### DIFF
--- a/opaleye.cabal
+++ b/opaleye.cabal
@@ -33,7 +33,7 @@ library
     , case-insensitive    >= 1.2     && < 1.3
     , bytestring          >= 0.10    && < 0.11
     , contravariant       >= 1.2     && < 1.4
-    , postgresql-simple   >= 0.4.8.0 && < 0.6
+    , postgresql-simple   >= 0.5     && < 0.6
     , pretty              >= 1.1.1.0 && < 1.2
     , product-profunctors >= 0.6.2   && < 0.7
     , profunctors         >= 4.0     && < 5.2


### PR DESCRIPTION
**Note:** This will not work until [postgresql-simple commit e8562d6](https://github.com/tstat/postgresql-simple/commit/e8562d63c0807d32c70808a3aac289ce1d0f3e85) is published to hackage.

Because the where clause of `runQueryFoldExplicit` is a direct copy of `runQueryExplicit` I pulled out a function I named `prepareQuery`. I am not sure what module would be the best place for this function so any advice on that would be appreciated.