### PR TITLE
Allow column names with capital letters

### DIFF
--- a/src/Opaleye/Internal/HaskellDB/Sql/Print.hs
+++ b/src/Opaleye/Internal/HaskellDB/Sql/Print.hs
@@ -70,7 +70,7 @@ ppSqlNulls x = text $ case Sql.sqlOrderNulls x of
 
 ppAs :: String -> Doc -> Doc
 ppAs alias expr    | null alias    = expr
-                   | otherwise     = expr <+> (hsep . map text) ["as",alias]
+                   | otherwise     = expr <+> hsep [text "as", doubleQuotes (text alias)]
 
 
 ppUpdate :: SqlUpdate -> Doc


### PR DESCRIPTION
Currently Opaleye declares column aliases without wrapping the alias in double quotes but wraps references to them in double quotes. 

This becomes a problem if a column contains capital letters because postgres automatically converts column names not wrapped in double quotes to lower case. This causes the alias declared to not match the alias reference.

As a brief example consider:
```haskell
import           Opaleye
import           Data.Profunctor.Product (p2)

personTable :: Table (Column PGText, Column PGInt4)
                     (Column PGText, Column PGInt4)
personTable = Table "personTable" (p2 ( required "fullName"
                                      , required "age"))

main :: IO ()
main = putStrLn . showSqlForPostgres $ queryTable personTable

```
which generates the SQL:
```sql
SELECT "fullName0_1" as result1_2,
       "age1_1" as result2_2
FROM (SELECT *
      FROM (SELECT "fullName" as fullName0_1,
                   "age" as age1_1
            FROM "personTable" as T1) as T1) as T1
```
The `fullName0_1` alias is declared without quotes but the outer SELECT statement references it within double quotes.

This change just wraps aliases in double quotes to solve this problem.