### PR TITLE
Expose QueryRunnerColumnDefault from RunQuery

### DIFF
--- a/src/Opaleye/RunQuery.hs
+++ b/src/Opaleye/RunQuery.hs
@@ -3,6 +3,7 @@
 module Opaleye.RunQuery (module Opaleye.RunQuery,
                          QueryRunner,
                          IRQ.QueryRunnerColumn,
+                         IRQ.QueryRunnerColumnDefault (..),
                          IRQ.fieldQueryRunnerColumn) where
 
 import qualified Database.PostgreSQL.Simple as PGS


### PR DESCRIPTION
We are using this in [our TH for generating column instances](https://github.com/silkapp/silk-opaleye/blob/master/src/Silk/Opaleye/TH/Column.hs)
