### PR TITLE
Composite Types (Issue #98)

### DIFF
--- a/src/Opaleye/Column.hs
+++ b/src/Opaleye/Column.hs
@@ -2,9 +2,11 @@ module Opaleye.Column (module Opaleye.Column,
                        Column,
                        Nullable,
                        unsafeCoerce,
-                       unsafeCoerceColumn)  where
+                       unsafeCoerceColumn,
+                       unsafeCompositeField)  where
 
-import           Opaleye.Internal.Column (Column, Nullable, unsafeCoerce, unsafeCoerceColumn)
+import           Opaleye.Internal.Column (Column, Nullable, unsafeCoerce, unsafeCoerceColumn, 
+                                          unsafeCompositeField)
 import qualified Opaleye.Internal.Column as C
 import qualified Opaleye.Internal.HaskellDB.PrimQuery as HPQ
 import qualified Opaleye.PGTypes as T

--- a/src/Opaleye/Internal/Column.hs
+++ b/src/Opaleye/Internal/Column.hs
@@ -19,6 +19,10 @@ unsafeCoerce = unsafeCoerceColumn
 unsafeCoerceColumn :: Column a -> Column b
 unsafeCoerceColumn (Column e) = Column e
 
+unsafeCompositeField :: Column a -> String -> Column b
+unsafeCompositeField (Column e) fieldName = 
+  Column (HPQ.CompositeExpr e fieldName)
+
 binOp :: HPQ.BinOp -> Column a -> Column b -> Column c
 binOp op (Column e) (Column e') = Column (HPQ.BinExpr op e e')
 

--- a/src/Opaleye/Internal/HaskellDB/PrimQuery.hs
+++ b/src/Opaleye/Internal/HaskellDB/PrimQuery.hs
@@ -17,6 +17,7 @@ data Symbol = Symbol String T.Tag deriving (Read, Show)
 
 data PrimExpr   = AttrExpr  Symbol
                 | BaseTableAttrExpr Attribute
+                | CompositeExpr     PrimExpr Attribute -- ^ Composite Type Query
                 | BinExpr   BinOp PrimExpr PrimExpr
                 | UnExpr    UnOp PrimExpr
                 | AggrExpr  AggrOp PrimExpr

--- a/src/Opaleye/Internal/HaskellDB/Sql.hs
+++ b/src/Opaleye/Internal/HaskellDB/Sql.hs
@@ -30,6 +30,7 @@ data SqlOrder = SqlOrder { sqlOrderDirection :: SqlOrderDirection
 
 -- | Expressions in SQL statements.
 data SqlExpr = ColumnSqlExpr  SqlColumn
+             | CompositeSqlExpr SqlExpr String
              | BinSqlExpr     String SqlExpr SqlExpr
              | PrefixSqlExpr  String SqlExpr
              | PostfixSqlExpr String SqlExpr

--- a/src/Opaleye/Internal/HaskellDB/Sql/Default.hs
+++ b/src/Opaleye/Internal/HaskellDB/Sql/Default.hs
@@ -80,6 +80,7 @@ defaultSqlExpr gen expr =
     case expr of
       AttrExpr (Symbol a t) -> ColumnSqlExpr (SqlColumn (tagWith t a))
       BaseTableAttrExpr a -> ColumnSqlExpr (SqlColumn a)
+      CompositeExpr e x -> CompositeSqlExpr (defaultSqlExpr gen e) x
       BinExpr op e1 e2 ->
         let leftE = sqlExpr gen e1
             rightE = sqlExpr gen e2

--- a/src/Opaleye/Internal/HaskellDB/Sql/Print.hs
+++ b/src/Opaleye/Internal/HaskellDB/Sql/Print.hs
@@ -113,6 +113,7 @@ ppSqlExpr :: SqlExpr -> Doc
 ppSqlExpr expr =
     case expr of
       ColumnSqlExpr c     -> ppColumn c
+      CompositeSqlExpr s x -> parens (ppSqlExpr s) <> text "." <> text x
       ParensSqlExpr e -> parens (ppSqlExpr e)
       BinSqlExpr op e1 e2 -> ppSqlExpr e1 <+> text op <+> ppSqlExpr e2
       PrefixSqlExpr op e  -> text op <+> ppSqlExpr e

--- a/src/Opaleye/Internal/Table.hs
+++ b/src/Opaleye/Internal/Table.hs
@@ -88,6 +88,7 @@ runColumnMaker cm tag tableCols = PM.run (TM.runColumnMaker cm f tableCols) wher
   -- tablecols contained in the View (which would be naughty)
   mkName pe i = (++ i) $ case pe of
     HPQ.BaseTableAttrExpr columnName -> columnName
+    HPQ.CompositeExpr columnExpr fieldName -> mkName columnExpr i ++ fieldName
     _ -> "tablecolumn"
 
 runWriter :: Writer columns columns' -> columns -> [(HPQ.PrimExpr, String)]


### PR DESCRIPTION
Adding composite types by creating a new data type Composite, which plays a similar role to Column. Created a new expression constructor for HaskellDB's PrimQuery, and modified HaskellDB's SqlColumn type.

Here's an example of using it:
```sql
create type location as (
    x double precision,
    y double precision
);

create table locations (
    id serial primary key,
    location1 location,
    location2 location
);
```

```haskell
{-# LANGUAGE EmptyDataDecls        #-}
{-# LANGUAGE FlexibleInstances     #-}
{-# LANGUAGE MultiParamTypeClasses #-}
{-# LANGUAGE OverloadedStrings     #-}
{-# LANGUAGE TemplateHaskell       #-}

module Main where

import           Data.Maybe                           (listToMaybe)
import           Data.Profunctor.Product.Default      as D
import           Data.Profunctor.Product.TH           (makeAdaptorAndInstance)

import qualified Database.PostgreSQL.Simple           as PSQL
import           Database.PostgreSQL.Simple.FromRow

import           Opaleye                              hiding (literalColumn)
import           Opaleye.Internal.Column
import           Opaleye.Internal.HaskellDB.PrimQuery as HPQ
import           Opaleye.Internal.PGTypes
import           Opaleye.Internal.RunQuery

data Location = Location
    { x :: Double
    , y :: Double
    } deriving (Show, Eq)

data PGLocation

pgLocation :: Location -> Composite PGLocation
pgLocation (Location x y) = WriteComposite . HPQ.ConstExpr . HPQ.OtherLit $
    "(" ++ show x ++ "::double precision," ++ show y ++ "::double precision)"

instance FromRow Location where
    fromRow = Location <$> field <*> field

instance D.Default QueryRunner (Composite PGLocation) Location where
    def = rowQueryRunner

data Locations = Locations
    { l1 :: Location
    , l2 :: Location
    } deriving (Show, Eq)

data LocationsP i a b = LocationsP
    { pId :: i
    , pl1 :: a
    , pl2 :: b
    } deriving (Show, Eq)

makeAdaptorAndInstance "pLocations" ''LocationsP

type WriteLocations = LocationsP
    (Maybe (Column PGInt4))
    (Composite PGLocation)
    (Composite PGLocation)

type ReadLocations = LocationsP
    (Column PGInt4)
    (Composite PGLocation)
    (Composite PGLocation)

locationsTable :: Table WriteLocations ReadLocations
locationsTable = Table "locations"
    (pLocations LocationsP
        { pId = optional "id"
        , pl1 = compositeRequired "location1" ["x", "y"]
        , pl2 = compositeRequired "location2" ["x", "y"]
        })

selectAllLocations :: Query ReadLocations
selectAllLocations = queryTable locationsTable

runLocationsQuery :: PSQL.Connection -> Query ReadLocations -> IO [(Int, Locations)]
runLocationsQuery c q = map mkLocations <$> runQuery c q
  where
    mkLocations :: LocationsP Int Location Location -> (Int, Locations)
    mkLocations (LocationsP i p1 p2) = (i, Locations p1 p2)

insertLocations :: PSQL.Connection -> Locations -> IO (Maybe Int)
insertLocations c (Locations p1 p2) =
    listToMaybe <$> runInsertReturning c locationsTable wlocations pId
  where
    wlocations = LocationsP Nothing (pgLocation p1) (pgLocation p2)

main :: IO ()
main = do
    c <- PSQL.connectPostgreSQL "dbname='testpoints' user='postgres'"

    printSql selectAllLocations

    _ <- insertLocations c (Locations (Location 1.2 2.1) (Location 2.3 62.1))
    _ <- insertLocations c (Locations (Location 3.2 6.1) (Location 2 51.1))
    runLocationsQuery c selectAllLocations >>= printLines
  where
    printSql = putStrLn . showSqlForPostgres
    printLines = putStrLn . unlines . map show
```