### PR TITLE
Support table schemas other than PostgreSQL's default "public"

### DIFF
--- a/Doc/Tutorial/TutorialBasic.lhs
+++ b/Doc/Tutorial/TutorialBasic.lhs
@@ -64,6 +64,10 @@ manipulation tutorial you can see an example of when they might differ.
 >                                       , required "age"
 >                                       , required "address" ))
 
+By default, the table `"personTable"` is looked up in PostgreSQL's
+default `"public"` schema. If we wanted to specify a different schema we
+could have used the `TableWithSchema` constructor instead of `Table`.
+
 To query a table we use `queryTable`.
 
 (Here and in a few other places in Opaleye there is some typeclass

--- a/Test/Test.hs
+++ b/Test/Test.hs
@@ -137,7 +137,7 @@ table4 = twoIntTable "table4"
 
 table5 :: O.Table (Maybe (Column O.PGInt4), Maybe (Column  O.PGInt4))
                   (Column O.PGInt4, Column O.PGInt4)
-table5 = O.Table "table5" (PP.p2 (O.optional "column1", O.optional "column2"))
+table5 = O.TableWithSchema "public" "table5" (PP.p2 (O.optional "column1", O.optional "column2"))
 
 table6 :: O.Table (Column O.PGText, Column O.PGText) (Column O.PGText, Column O.PGText)
 table6 = O.Table "table6" (PP.p2 (O.required "column1", O.required "column2"))
@@ -209,8 +209,8 @@ table6columndata = map (\(column1, column2) -> (O.pgString column1, O.pgString c
 -- table names are treated as lower case unless the name is quoted!
 dropAndCreateTable :: String -> (String, [String]) -> PGS.Query
 dropAndCreateTable columnType (t, cols) = String.fromString drop_
-  where drop_ = "DROP TABLE IF EXISTS \"" ++ t ++ "\";"
-                ++ "CREATE TABLE \"" ++ t ++ "\""
+  where drop_ = "DROP TABLE IF EXISTS \"public\".\"" ++ t ++ "\";"
+                ++ "CREATE TABLE \"public\".\"" ++ t ++ "\""
                 ++ " (" ++ commas cols ++ ");"
         integer c = ("\"" ++ c ++ "\"" ++ " " ++ columnType)
         commas = L.intercalate "," . map integer
@@ -225,8 +225,8 @@ dropAndCreateTableText = dropAndCreateTable "text"
 -- table names are treated as lower case unless the name is quoted!
 dropAndCreateTableSerial :: (String, [String]) -> PGS.Query
 dropAndCreateTableSerial (t, cols) = String.fromString drop_
-  where drop_ = "DROP TABLE IF EXISTS \"" ++ t ++ "\";"
-                ++ "CREATE TABLE \"" ++ t ++ "\""
+  where drop_ = "DROP TABLE IF EXISTS \"public\".\"" ++ t ++ "\";"
+                ++ "CREATE TABLE \"public\".\"" ++ t ++ "\""
                 ++ " (" ++ commas cols ++ ");"
         integer c = ("\"" ++ c ++ "\"" ++ " SERIAL")
         commas = L.intercalate "," . map integer

--- a/src/Opaleye/Internal/HaskellDB/Sql.hs
+++ b/src/Opaleye/Internal/HaskellDB/Sql.hs
@@ -11,7 +11,10 @@ import qualified Data.List.NonEmpty as NEL
 -- * SQL data type
 -----------------------------------------------------------
 
-newtype SqlTable = SqlTable String deriving Show
+data SqlTable = SqlTable
+  { sqlTableSchemaName :: Maybe String
+  , sqlTableName       :: String
+  } deriving Show
 
 newtype SqlColumn = SqlColumn String deriving Show
 

--- a/src/Opaleye/Internal/HaskellDB/Sql/Default.hs
+++ b/src/Opaleye/Internal/HaskellDB/Sql/Default.hs
@@ -50,29 +50,29 @@ toSqlAssoc gen = map (\(attr,expr) -> (toSqlColumn attr, sqlExpr gen expr))
 
 
 defaultSqlUpdate :: SqlGenerator
-                 -> TableName  -- ^ Name of the table to update.
+                 -> SqlTable   -- ^ Table to update
                  -> [PrimExpr] -- ^ Conditions which must all be true for a row
                                --   to be updated.
                  -> Assoc -- ^ Update the data with this.
                  -> SqlUpdate
-defaultSqlUpdate gen name criteria assigns
-        = SqlUpdate (SqlTable name) (toSqlAssoc gen assigns) (map (sqlExpr gen) criteria)
+defaultSqlUpdate gen tbl criteria assigns
+        = SqlUpdate tbl (toSqlAssoc gen assigns) (map (sqlExpr gen) criteria)
 
 
 defaultSqlInsert :: SqlGenerator
-                 -> TableName
+                 -> SqlTable
                  -> [Attribute]
                  -> NEL.NonEmpty [PrimExpr]
                  -> SqlInsert
-defaultSqlInsert gen name attrs exprs =
-  SqlInsert (SqlTable name) (map toSqlColumn attrs) ((fmap . map) (sqlExpr gen) exprs)
+defaultSqlInsert gen tbl attrs exprs =
+  SqlInsert tbl (map toSqlColumn attrs) ((fmap . map) (sqlExpr gen) exprs)
 
 defaultSqlDelete :: SqlGenerator
-                 -> TableName -- ^ Name of the table
+                 -> SqlTable
                  -> [PrimExpr] -- ^ Criteria which must all be true for a row
                                --   to be deleted.
                  -> SqlDelete
-defaultSqlDelete gen name criteria = SqlDelete (SqlTable name) (map (sqlExpr gen) criteria)
+defaultSqlDelete gen tbl criteria = SqlDelete tbl (map (sqlExpr gen) criteria)
 
 
 defaultSqlExpr :: SqlGenerator -> PrimExpr -> SqlExpr

--- a/src/Opaleye/Internal/HaskellDB/Sql/Generate.hs
+++ b/src/Opaleye/Internal/HaskellDB/Sql/Generate.hs
@@ -11,9 +11,9 @@ import qualified Data.List.NonEmpty as NEL
 
 data SqlGenerator = SqlGenerator
     {
-     sqlUpdate      :: TableName -> [PrimExpr] -> Assoc -> SqlUpdate,
-     sqlDelete      :: TableName -> [PrimExpr] -> SqlDelete,
-     sqlInsert      :: TableName -> [Attribute] -> NEL.NonEmpty [PrimExpr] -> SqlInsert,
+     sqlUpdate      :: SqlTable -> [PrimExpr] -> Assoc -> SqlUpdate,
+     sqlDelete      :: SqlTable -> [PrimExpr] -> SqlDelete,
+     sqlInsert      :: SqlTable -> [Attribute] -> NEL.NonEmpty [PrimExpr] -> SqlInsert,
      sqlExpr        :: PrimExpr -> SqlExpr,
      sqlLiteral     :: Literal -> String,
      -- | Turn a string into a quoted string. Quote characters

--- a/src/Opaleye/Internal/HaskellDB/Sql/Print.hs
+++ b/src/Opaleye/Internal/HaskellDB/Sql/Print.hs
@@ -104,10 +104,14 @@ ppInsert (SqlInsert table names values)
 ppColumn :: SqlColumn -> Doc
 ppColumn (SqlColumn s) = doubleQuotes (text s)
 
--- Postgres treats upper case letters in table names as lower case,
--- unless the name is quoted!
+-- Postgres treats schema and table names as lower case unless quoted.
 ppTable :: SqlTable -> Doc
-ppTable (SqlTable s) = doubleQuotes (text s)
+ppTable st = case sqlTableSchemaName st of
+    Just sn -> doubleQuotes (text sn) <> text "." <> tname
+    Nothing -> tname
+  where
+    tname = doubleQuotes (text (sqlTableName st))
+
 
 ppSqlExpr :: SqlExpr -> Doc
 ppSqlExpr expr =

--- a/src/Opaleye/Internal/Sql.hs
+++ b/src/Opaleye/Internal/Sql.hs
@@ -61,8 +61,6 @@ data Binary = Binary {
 data JoinType = LeftJoin deriving Show
 data BinOp = Except | Union | UnionAll deriving Show
 
-data TableName = String
-
 data Returning a = Returning a (NEL.NonEmpty HSql.SqlExpr)
 
 sqlQueryGenerator :: PQ.PrimQueryFold Select
@@ -79,10 +77,10 @@ sql (pes, pq, t) = SelectFrom $ newSelect { attrs = SelectAttrs (ensureColumns (
 unit :: Select
 unit = SelectFrom newSelect { attrs  = SelectAttrs (ensureColumns []) }
 
-baseTable :: String -> [(Symbol, HPQ.PrimExpr)] -> Select
-baseTable name columns = SelectFrom $
+baseTable :: PQ.TableIdentifier -> [(Symbol, HPQ.PrimExpr)] -> Select
+baseTable ti columns = SelectFrom $
     newSelect { attrs = SelectAttrs (ensureColumns (map sqlBinding columns))
-              , tables = [Table (HSql.SqlTable name)] }
+              , tables = [Table (HSql.SqlTable (PQ.tiSchemaName ti) (PQ.tiTableName ti))] }
 
 product :: NEL.NonEmpty Select -> [HPQ.PrimExpr] -> Select
 product ss pes = SelectFrom $

--- a/src/Opaleye/Manipulation.hs
+++ b/src/Opaleye/Manipulation.hs
@@ -11,6 +11,7 @@ import qualified Opaleye.Table as T
 import qualified Opaleye.Internal.Table as TI
 import           Opaleye.Internal.Column (Column(Column))
 import           Opaleye.Internal.Helpers ((.:), (.:.), (.::), (.::.))
+import qualified Opaleye.Internal.PrimQuery as PQ
 import qualified Opaleye.Internal.Unpackspec as U
 import           Opaleye.PGTypes (PGBool)
 
@@ -37,10 +38,12 @@ runInsert :: PGS.Connection -> T.Table columns columns' -> columns -> IO Int64
 runInsert conn = PGS.execute_ conn . fromString .: arrangeInsertSql
 
 arrangeInsertMany :: T.Table columns a -> NEL.NonEmpty columns -> HSql.SqlInsert
-arrangeInsertMany (T.Table tableName (TI.TableProperties writer _)) columns = insert
-  where (columnExprs, columnNames) = TI.runWriter' writer columns
+arrangeInsertMany table columns = insert
+  where writer = TI.tablePropertiesWriter (TI.tableProperties table)
+        (columnExprs, columnNames) = TI.runWriter' writer columns
         insert = SG.sqlInsert SD.defaultSqlGenerator
-                      tableName columnNames columnExprs
+                      (TI.tableName table)
+                      columnNames columnExprs
 
 arrangeInsertManySql :: T.Table columns a -> NEL.NonEmpty columns -> String
 arrangeInsertManySql = show . HPrint.ppInsert .: arrangeInsertMany
@@ -57,12 +60,12 @@ runInsertMany conn table columns = case NEL.nonEmpty columns of
 arrangeUpdate :: T.Table columnsW columnsR
               -> (columnsR -> columnsW) -> (columnsR -> Column PGBool)
               -> HSql.SqlUpdate
-arrangeUpdate (TI.Table tableName (TI.TableProperties writer (TI.View tableCols)))
-              update cond =
-  SG.sqlUpdate SD.defaultSqlGenerator tableName [condExpr] (update' tableCols)
-  where update' = map (\(x, y) -> (y, x))
-                   . TI.runWriter writer
-                   . update
+arrangeUpdate table update cond =
+  SG.sqlUpdate SD.defaultSqlGenerator
+               (TI.tableName table)
+               [condExpr] (update' tableCols)
+  where TI.TableProperties writer (TI.View tableCols) = TI.tableProperties table
+        update' = map (\(x, y) -> (y, x)) . TI.runWriter writer . update
         Column condExpr = cond tableCols
 
 arrangeUpdateSql :: T.Table columnsW columnsR
@@ -76,10 +79,10 @@ runUpdate :: PGS.Connection -> T.Table columnsW columnsR
 runUpdate conn = PGS.execute_ conn . fromString .:. arrangeUpdateSql
 
 arrangeDelete :: T.Table a columnsR -> (columnsR -> Column PGBool) -> HSql.SqlDelete
-arrangeDelete (TI.Table tableName (TI.TableProperties _ (TI.View tableCols)))
-              cond =
-  SG.sqlDelete SD.defaultSqlGenerator tableName [condExpr]
+arrangeDelete table cond =
+  SG.sqlDelete SD.defaultSqlGenerator (TI.tableName table) [condExpr]
   where Column condExpr = cond tableCols
+        TI.View tableCols = TI.tablePropertiesView (TI.tableProperties table)
 
 arrangeDeleteSql :: T.Table a columnsR -> (columnsR -> Column PGBool) -> String
 arrangeDeleteSql = show . HPrint.ppDelete .: arrangeDelete
@@ -96,7 +99,7 @@ arrangeInsertReturning :: U.Unpackspec returned ignored
 arrangeInsertReturning unpackspec table columns returningf =
   Sql.Returning insert returningSEs
   where insert = arrangeInsert table columns
-        TI.Table _ (TI.TableProperties _ (TI.View columnsR)) = table
+        TI.View columnsR = TI.tablePropertiesView (TI.tableProperties table)
         returningPEs = U.collectPEs unpackspec (returningf columnsR)
         returningSEs = Sql.ensureColumnsGen id (map Sql.sqlExpr returningPEs)
 
@@ -120,7 +123,7 @@ runInsertReturningExplicit qr conn t w r = PGS.queryWith_ parser conn
                                              (arrangeInsertReturningSql u t w r))
   where IRQ.QueryRunner u _ _ = qr
         parser = IRQ.prepareRowParser qr (r v)
-        TI.Table _ (TI.TableProperties _ (TI.View v)) = t
+        TI.View v = TI.tablePropertiesView (TI.tableProperties t)
         -- This method of getting hold of the return type feels a bit
         -- suspect.  I haven't checked it for validity.
 
@@ -145,7 +148,7 @@ arrangeUpdateReturning :: U.Unpackspec returned ignored
 arrangeUpdateReturning unpackspec table updatef cond returningf =
   Sql.Returning update returningSEs
   where update = arrangeUpdate table updatef cond
-        TI.Table _ (TI.TableProperties _ (TI.View columnsR)) = table
+        TI.View columnsR = TI.tablePropertiesView (TI.tableProperties table)
         returningPEs = U.collectPEs unpackspec (returningf columnsR)
         returningSEs = Sql.ensureColumnsGen id (map Sql.sqlExpr returningPEs)
 
@@ -171,7 +174,7 @@ runUpdateReturningExplicit qr conn t update cond r =
                  (fromString (arrangeUpdateReturningSql u t update cond r))
   where IRQ.QueryRunner u _ _ = qr
         parser = IRQ.prepareRowParser qr (r v)
-        TI.Table _ (TI.TableProperties _ (TI.View v)) = t
+        TI.View v = TI.tablePropertiesView (TI.tableProperties t)
 
 runUpdateReturning :: (D.Default RQ.QueryRunner returned haskells)
                       => PGS.Connection

--- a/src/Opaleye/Manipulation.hs
+++ b/src/Opaleye/Manipulation.hs
@@ -42,7 +42,7 @@ arrangeInsertMany table columns = insert
   where writer = TI.tablePropertiesWriter (TI.tableProperties table)
         (columnExprs, columnNames) = TI.runWriter' writer columns
         insert = SG.sqlInsert SD.defaultSqlGenerator
-                      (TI.tableName table)
+                      (PQ.tiToSqlTable (TI.tableIdentifier table))
                       columnNames columnExprs
 
 arrangeInsertManySql :: T.Table columns a -> NEL.NonEmpty columns -> String
@@ -62,7 +62,7 @@ arrangeUpdate :: T.Table columnsW columnsR
               -> HSql.SqlUpdate
 arrangeUpdate table update cond =
   SG.sqlUpdate SD.defaultSqlGenerator
-               (TI.tableName table)
+               (PQ.tiToSqlTable (TI.tableIdentifier table))
                [condExpr] (update' tableCols)
   where TI.TableProperties writer (TI.View tableCols) = TI.tableProperties table
         update' = map (\(x, y) -> (y, x)) . TI.runWriter writer . update
@@ -80,7 +80,7 @@ runUpdate conn = PGS.execute_ conn . fromString .:. arrangeUpdateSql
 
 arrangeDelete :: T.Table a columnsR -> (columnsR -> Column PGBool) -> HSql.SqlDelete
 arrangeDelete table cond =
-  SG.sqlDelete SD.defaultSqlGenerator (TI.tableName table) [condExpr]
+  SG.sqlDelete SD.defaultSqlGenerator (PQ.tiToSqlTable (TI.tableIdentifier table)) [condExpr]
   where Column condExpr = cond tableCols
         TI.View tableCols = TI.tablePropertiesView (TI.tableProperties table)
 

--- a/src/Opaleye/Table.hs
+++ b/src/Opaleye/Table.hs
@@ -3,7 +3,7 @@
 module Opaleye.Table (module Opaleye.Table,
                       View,
                       Writer,
-                      Table(Table),
+                      Table(Table, TableWithSchema),
                       TableProperties) where
 
 import           Opaleye.Internal.Column (Column(Column))


### PR DESCRIPTION
This is a backwards incompatible change that adds another parameter to the `Table` constructor so that the schema where the table is found can be specified.

http://www.postgresql.org/docs/9.3/static/ddl-schemas.html