### PR TITLE
Render SQL statements in a single line.

### DIFF
--- a/Test/Test.hs
+++ b/Test/Test.hs
@@ -200,7 +200,7 @@ table4columndata :: [(Column O.PGInt4, Column O.PGInt4)]
 table4columndata = table4dataG
 
 table6data :: [(String, String)]
-table6data = [("xy", "a"), ("z", "a"), ("more text", "a")]
+table6data = [("xy", "a"), ("z", "a"), ("more \n text", "a")]
 
 table6columndata :: [(Column O.PGText, Column O.PGText)]
 table6columndata = map (\(column1, column2) -> (O.pgString column1, O.pgString column2)) table6data

--- a/src/Opaleye/Internal/Print.hs
+++ b/src/Opaleye/Internal/Print.hs
@@ -12,9 +12,15 @@ import           Opaleye.Internal.Sql (Select(SelectFrom, Table,
 import qualified Opaleye.Internal.HaskellDB.Sql as HSql
 import qualified Opaleye.Internal.HaskellDB.Sql.Print as HPrint
 
+import qualified Text.PrettyPrint.HughesPJ as PP 
 import           Text.PrettyPrint.HughesPJ (Doc, ($$), (<+>), text, empty,
                                             parens)
+
 import qualified Data.List.NonEmpty as NEL
+
+
+renderDoc :: Doc -> String
+renderDoc = PP.renderStyle (PP.style {PP.mode = PP.OneLineMode})
 
 type TableAlias = String
 

--- a/src/Opaleye/Manipulation.hs
+++ b/src/Opaleye/Manipulation.hs
@@ -31,7 +31,7 @@ arrangeInsert :: T.Table columns a -> columns -> HSql.SqlInsert
 arrangeInsert t c = arrangeInsertMany t (return c)
 
 arrangeInsertSql :: T.Table columns a -> columns -> String
-arrangeInsertSql = show . HPrint.ppInsert .: arrangeInsert
+arrangeInsertSql = Print.renderDoc . HPrint.ppInsert .: arrangeInsert
 
 runInsert :: PGS.Connection -> T.Table columns columns' -> columns -> IO Int64
 runInsert conn = PGS.execute_ conn . fromString .: arrangeInsertSql
@@ -43,7 +43,7 @@ arrangeInsertMany (T.Table tableName (TI.TableProperties writer _)) columns = in
                       tableName columnNames columnExprs
 
 arrangeInsertManySql :: T.Table columns a -> NEL.NonEmpty columns -> String
-arrangeInsertManySql = show . HPrint.ppInsert .: arrangeInsertMany
+arrangeInsertManySql = Print.renderDoc . HPrint.ppInsert .: arrangeInsertMany
 
 runInsertMany :: PGS.Connection
               -> T.Table columns columns'
@@ -68,7 +68,7 @@ arrangeUpdate (TI.Table tableName (TI.TableProperties writer (TI.View tableCols)
 arrangeUpdateSql :: T.Table columnsW columnsR
               -> (columnsR -> columnsW) -> (columnsR -> Column PGBool)
               -> String
-arrangeUpdateSql = show . HPrint.ppUpdate .:. arrangeUpdate
+arrangeUpdateSql = Print.renderDoc . HPrint.ppUpdate .:. arrangeUpdate
 
 runUpdate :: PGS.Connection -> T.Table columnsW columnsR
           -> (columnsR -> columnsW) -> (columnsR -> Column PGBool)
@@ -82,7 +82,7 @@ arrangeDelete (TI.Table tableName (TI.TableProperties _ (TI.View tableCols)))
   where Column condExpr = cond tableCols
 
 arrangeDeleteSql :: T.Table a columnsR -> (columnsR -> Column PGBool) -> String
-arrangeDeleteSql = show . HPrint.ppDelete .: arrangeDelete
+arrangeDeleteSql = Print.renderDoc . HPrint.ppDelete .: arrangeDelete
 
 runDelete :: PGS.Connection -> T.Table a columnsR -> (columnsR -> Column PGBool)
           -> IO Int64
@@ -105,7 +105,7 @@ arrangeInsertReturningSql :: U.Unpackspec returned ignored
                           -> columnsW
                           -> (columnsR -> returned)
                           -> String
-arrangeInsertReturningSql = show
+arrangeInsertReturningSql = Print.renderDoc
                             . Print.ppInsertReturning
                             .:: arrangeInsertReturning
 
@@ -155,7 +155,7 @@ arrangeUpdateReturningSql :: U.Unpackspec returned ignored
                        -> (columnsR -> Column PGBool)
                        -> (columnsR -> returned)
                        -> String
-arrangeUpdateReturningSql = show
+arrangeUpdateReturningSql = Print.renderDoc
                             . Print.ppUpdateReturning
                             .::. arrangeUpdateReturning
 

--- a/src/Opaleye/Sql.hs
+++ b/src/Opaleye/Sql.hs
@@ -44,4 +44,4 @@ showSqlForPostgresUnoptExplicit :: U.Unpackspec columns b -> Q.Query columns -> 
 showSqlForPostgresUnoptExplicit = formatAndShowSQL .: Q.runQueryArrUnpack
 
 formatAndShowSQL :: ([HPQ.PrimExpr], PQ.PrimQuery, T.Tag) -> String
-formatAndShowSQL = show . Pr.ppSql . Sql.sql
+formatAndShowSQL = Pr.renderDoc . Pr.ppSql . Sql.sql


### PR DESCRIPTION
This change makes it easier to grep for queries in PostgreSQL's log, as well as copy-pasting said queries.