### PR TITLE
Slight fix to grammar - which vs that

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Brief introduction to Opaleye [![Hackage version](https://img.shields.io/hackage/v/opaleye.svg?style=flat)](https://hackage.haskell.org/package/opaleye) [![Build Status](https://img.shields.io/travis/tomjaguarpaw/haskell-opaleye.svg?style=flat)](https://travis-ci.org/tomjaguarpaw/haskell-opaleye)
 
-Opaleye is a Haskell library which provides an SQL-generating embedded
+Opaleye is a Haskell library that provides an SQL-generating embedded
 domain specific language for targeting Postgres.  You need Opaleye if
 you want to use Haskell to write typesafe and composable code to query
 a Postgres database.


### PR DESCRIPTION
"x is a y that provides" is better than "x is a y which provides" here, because we're talking about identity. "Which" is a pronoun & determiner used to refer to a previous clause, but "that" is a pronoun used to indroduce a defining or qualifying/restricting clause, in particular one used for talking about identity. Which is used when the clause provides inessential, incidental information. (Not the case here).