### PR TITLE
Add support `PGJson` and `PGJsonb` support for `Data.Aeson.Value`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Bump upper bound for `semigroups`.
 * Bump upper bound for `postgresql-simple`.
+* Added `pgValueJSON` and `pgValueJSONB`.
 
 ## 0.4.1.0
 

--- a/opaleye.cabal
+++ b/opaleye.cabal
@@ -27,7 +27,8 @@ library
   build-depends:
       -- attoparsec can be removed once postgresql-simple patch in
       -- Internal.RunQuery is merged upstream
-      attoparsec          >= 0.10.3  && < 0.14
+      aeson               >= 0.6     && < 0.10
+    , attoparsec          >= 0.10.3  && < 0.14
     , base                >= 4       && < 5
     , base16-bytestring   >= 0.1.1.6 && < 0.2
     , case-insensitive    >= 1.2     && < 1.3

--- a/opaleye.cabal
+++ b/opaleye.cabal
@@ -27,7 +27,7 @@ library
   build-depends:
       -- attoparsec can be removed once postgresql-simple patch in
       -- Internal.RunQuery is merged upstream
-      aeson               >= 0.6     && < 0.10
+      aeson               >= 0.6     && < 0.11
     , attoparsec          >= 0.10.3  && < 0.14
     , base                >= 4       && < 5
     , base16-bytestring   >= 0.1.1.6 && < 0.2

--- a/src/Opaleye/Constant.hs
+++ b/src/Opaleye/Constant.hs
@@ -6,6 +6,7 @@ import           Opaleye.Column                  (Column)
 import qualified Opaleye.Column                  as C
 import qualified Opaleye.PGTypes                 as T
 
+import qualified Data.Aeson                      as Ae
 import qualified Data.CaseInsensitive            as CI
 import qualified Data.Int                        as Int
 import qualified Data.Text                       as ST
@@ -89,11 +90,17 @@ instance D.Default Constant SBS.ByteString (Column T.PGJson) where
 instance D.Default Constant LBS.ByteString (Column T.PGJson) where
   def = Constant T.pgLazyJSON
 
+instance D.Default Constant Ae.Value (Column T.PGJson) where
+  def = Constant T.pgValueJSON
+
 instance D.Default Constant SBS.ByteString (Column T.PGJsonb) where
   def = Constant T.pgStrictJSONB
 
 instance D.Default Constant LBS.ByteString (Column T.PGJsonb) where
   def = Constant T.pgLazyJSONB
+
+instance D.Default Constant Ae.Value (Column T.PGJsonb) where
+  def = Constant T.pgValueJSONB
 
 -- { Boilerplate instances
 

--- a/src/Opaleye/Internal/RunQuery.hs
+++ b/src/Opaleye/Internal/RunQuery.hs
@@ -24,6 +24,7 @@ import qualified Data.Profunctor.Product as PP
 import           Data.Profunctor.Product (empty, (***!))
 import qualified Data.Profunctor.Product.Default as D
 
+import qualified Data.Aeson as Ae
 import qualified Data.CaseInsensitive as CI
 import qualified Data.Text as ST
 import qualified Data.Text.Lazy as LT
@@ -173,9 +174,15 @@ instance QueryRunnerColumnDefault T.PGJson String where
   queryRunnerColumnDefault =
     QueryRunnerColumn (P.rmap (const ()) U.unpackspecColumn) jsonFieldParser
 
+instance QueryRunnerColumnDefault T.PGJson Ae.Value where
+  queryRunnerColumnDefault = fieldQueryRunnerColumn
+
 instance QueryRunnerColumnDefault T.PGJsonb String where
   queryRunnerColumnDefault =
     QueryRunnerColumn (P.rmap (const ()) U.unpackspecColumn) jsonbFieldParser
+
+instance QueryRunnerColumnDefault T.PGJsonb Ae.Value where
+  queryRunnerColumnDefault = fieldQueryRunnerColumn
 
 -- No CI String instance since postgresql-simple doesn't define FromField (CI String)
 

--- a/src/Opaleye/PGTypes.hs
+++ b/src/Opaleye/PGTypes.hs
@@ -128,7 +128,7 @@ pgStrictJSON = pgJSON . IPT.strictDecodeUtf8
 pgLazyJSON :: LByteString.ByteString -> Column PGJson
 pgLazyJSON = pgJSON . IPT.lazyDecodeUtf8
 
-pgValueJSON :: Ae.Value -> Column PGJson
+pgValueJSON :: Ae.ToJSON a => a -> Column PGJson
 pgValueJSON = pgLazyJSON . Ae.encode
 
 -- The jsonb data type was introduced in PostgreSQL version 9.4
@@ -145,5 +145,5 @@ pgStrictJSONB = pgJSONB . IPT.strictDecodeUtf8
 pgLazyJSONB :: LByteString.ByteString -> Column PGJsonb
 pgLazyJSONB = pgJSONB . IPT.lazyDecodeUtf8
 
-pgValueJSONB :: Ae.Value -> Column PGJsonb
+pgValueJSONB :: Ae.ToJSON a => a -> Column PGJsonb
 pgValueJSONB = pgLazyJSONB . Ae.encode

--- a/src/Opaleye/PGTypes.hs
+++ b/src/Opaleye/PGTypes.hs
@@ -10,6 +10,7 @@ import qualified Opaleye.Internal.HaskellDB.PrimQuery as HPQ
 import qualified Opaleye.Internal.HaskellDB.Sql.Default as HSD (quote)
 
 import qualified Data.CaseInsensitive as CI
+import qualified Data.Aeson as Ae
 import qualified Data.Text as SText
 import qualified Data.Text.Lazy as LText
 import qualified Data.ByteString as SByteString
@@ -127,6 +128,9 @@ pgStrictJSON = pgJSON . IPT.strictDecodeUtf8
 pgLazyJSON :: LByteString.ByteString -> Column PGJson
 pgLazyJSON = pgJSON . IPT.lazyDecodeUtf8
 
+pgValueJSON :: Ae.Value -> Column PGJson
+pgValueJSON = pgLazyJSON . Ae.encode
+
 -- The jsonb data type was introduced in PostgreSQL version 9.4
 -- JSONB values must be SQL string quoted
 --
@@ -140,3 +144,6 @@ pgStrictJSONB = pgJSONB . IPT.strictDecodeUtf8
 
 pgLazyJSONB :: LByteString.ByteString -> Column PGJsonb
 pgLazyJSONB = pgJSONB . IPT.lazyDecodeUtf8
+
+pgValueJSONB :: Ae.Value -> Column PGJsonb
+pgValueJSONB = pgLazyJSONB . Ae.encode


### PR DESCRIPTION
The `aeson` library is already a transitional dependency through `postgresql-simple`.