### PR TITLE
Adding IN and NOT IN subquery operators.

### DIFF
--- a/src/Opaleye/Internal/HaskellDB/PrimQuery.hs
+++ b/src/Opaleye/Internal/HaskellDB/PrimQuery.hs
@@ -46,7 +46,7 @@ data Literal = NullLit
 
 data BinOp      = OpEq | OpLt | OpLtEq | OpGt | OpGtEq | OpNotEq
                 | OpAnd | OpOr
-                | OpLike | OpIn
+                | OpLike | OpIn | OpNotIn
                 | OpOther String
 
                 | OpCat

--- a/src/Opaleye/Internal/HaskellDB/Sql/Default.hs
+++ b/src/Opaleye/Internal/HaskellDB/Sql/Default.hs
@@ -145,6 +145,7 @@ showBinOp  OpAnd        = "AND"
 showBinOp  OpOr         = "OR"
 showBinOp  OpLike       = "LIKE"
 showBinOp  OpIn         = "IN"
+showBinOp  OpNotIn      = "NOT IN"
 showBinOp  (OpOther s)  = s
 showBinOp  OpCat        = "||"
 showBinOp  OpPlus       = "+"
@@ -157,7 +158,7 @@ showBinOp  OpBitAnd     = "&"
 showBinOp  OpBitOr      = "|"
 showBinOp  OpBitXor     = "^"
 showBinOp  OpAsg        = "="
-
+ 
 
 data UnOpType = UnOpFun | UnOpPrefix | UnOpPostfix
 

--- a/src/Opaleye/Operators.hs
+++ b/src/Opaleye/Operators.hs
@@ -31,6 +31,22 @@ restrict :: QueryArr (Column T.PGBool) ()
 restrict = QueryArr f where
   f (Column predicate, primQ, t0) = ((), PQ.restrict predicate primQ, t0)
 
+{-| Restrict a column using the IN operator. -}
+columnIn :: QueryArr () (Column a) -> QueryArr (Column a) ()
+columnIn (QueryArr q) = QueryArr f
+  where 
+    f (Column colName, primQ', t0) = 
+        let (Column colResult, primQ, t1) = q ((), primQ', t0) in
+        ((), PQ.Product (return primQ) [HPQ.BinExpr HPQ.OpIn colName colResult], t1)
+
+{-| Restrict a column using the NOT IN operator. -}
+columnNotIn :: QueryArr () (Column a) -> QueryArr (Column a) ()
+columnNotIn (QueryArr q) = QueryArr f
+  where 
+    f (Column colName, primQ', t0) = 
+        let (Column colResult, primQ, t1) = q ((), primQ', t0) in
+        ((), PQ.Product (return primQ) [HPQ.BinExpr HPQ.OpNotIn colName colResult], t1)
+
 {-| Filter a 'QueryArr' to only those rows where the given condition
 holds.  This is the 'QueryArr' equivalent of 'Prelude.filter' from the
 'Prelude'.  You would typically use 'keepWhen' if you want to use a

--- a/src/Opaleye/Operators.hs
+++ b/src/Opaleye/Operators.hs
@@ -31,22 +31,6 @@ restrict :: QueryArr (Column T.PGBool) ()
 restrict = QueryArr f where
   f (Column predicate, primQ, t0) = ((), PQ.restrict predicate primQ, t0)
 
-{-| Restrict a column using the IN operator. -}
-columnIn :: QueryArr () (Column a) -> QueryArr (Column a) ()
-columnIn (QueryArr q) = QueryArr f
-  where 
-    f (Column colName, primQ', t0) = 
-        let (Column colResult, primQ, t1) = q ((), primQ', t0) in
-        ((), PQ.Product (return primQ) [HPQ.BinExpr HPQ.OpIn colName colResult], t1)
-
-{-| Restrict a column using the NOT IN operator. -}
-columnNotIn :: QueryArr () (Column a) -> QueryArr (Column a) ()
-columnNotIn (QueryArr q) = QueryArr f
-  where 
-    f (Column colName, primQ', t0) = 
-        let (Column colResult, primQ, t1) = q ((), primQ', t0) in
-        ((), PQ.Product (return primQ) [HPQ.BinExpr HPQ.OpNotIn colName colResult], t1)
-
 {-| Filter a 'QueryArr' to only those rows where the given condition
 holds.  This is the 'QueryArr' equivalent of 'Prelude.filter' from the
 'Prelude'.  You would typically use 'keepWhen' if you want to use a
@@ -121,6 +105,14 @@ upper = C.unOp HPQ.OpUpper
 
 like :: Column T.PGText -> Column T.PGText -> Column T.PGBool
 like = C.binOp HPQ.OpLike
+
+{-| Restrict a column using the IN operator. -}
+columnIn :: Column a -> Column a -> Column T.PGBool
+columnIn = C.binOp HPQ.OpIn
+
+{-| Restrict a column using the NOT IN operator. -}
+columnNotIn :: Column a -> Column a -> Column T.PGBool
+columnNotIn = C.binOp HPQ.OpNotIn
 
 -- | True when any element of the container is true
 ors :: F.Foldable f => f (Column T.PGBool) -> Column T.PGBool


### PR DESCRIPTION
This adds the `IN` and `NOT IN` operators for subqueries rather than simply `Foldable` haskell data structures as done in issue #21. The new functions introduced here are `columnIn` and `columnNotIn` respectively.

```haskell
columnIn :: Query (Column a) -> QueryArr (Column a) ()
columnNotIn :: Query (Column a) -> QueryArr (Column a) ()
```

Here's an example:

```sql
CREATE TABLE person (
    id serial primary key,
    name text,
    age int4
);

CREATE TABLE test_people (
    person_id int4 references person(id)
);
```

can be queried with:

```haskell
data PersonP i n a = PersonP
    { personId :: i
    , pname    :: n
    , page     :: a
    } deriving (Show, Eq)

makeAdaptorAndInstance "pPerson" ''PersonP

type WritePerson = PersonP
    (Maybe (Column PGInt4))
    (Column PGText)
    (Column PGInt4)

type ReadPerson = PersonP
    (Column PGInt4)
    (Column PGText)
    (Column PGInt4)

personTable :: Table WritePerson ReadPerson
personTable = Table "person"
    (pPerson PersonP
        { personId = optional "id"
        , pname = required "name"
        , page = required "age"
        })

testPeopleTable :: Table (Column PGInt4) (Column PGInt4)
testPeopleTable = Table "test_people" (p1 (required "person_id"))

testQuery :: Query ReadPerson
testQuery = proc () -> do
    row@(PersonP pid _ _) <- queryTable personTable -< ()
    columnNotIn (queryTable testPeopleTable) -< pid
    returnA -< row
```

which produces the following SQL:

```sql
SELECT "id0_1" as "result1_3",
       "name1_1" as "result2_3",
       "age2_1" as "result3_3"
FROM (SELECT *
      FROM (SELECT "id" as "id0_1",
                   "name" as "name1_1",
                   "age" as "age2_1"
            FROM "person" as "T1") as "T1",
           (SELECT "person_id" as "person_id0_2"
            FROM "test_people" as "T1") as "T2"
      WHERE (("id0_1") NOT IN ("person_id0_2"))) as "T1"
```

I'm not absolutely certain about the `as "Tx"` part of the code. Please let me know if there is a mistake, and I'd be happy to fix it. However, I tested these queries, and it works as intended.