### PR TITLE
Array literals

### DIFF
--- a/Test/Test.hs
+++ b/Test/Test.hs
@@ -674,12 +674,12 @@ testEmptyArray :: Test
 testEmptyArray = testG (A.pure $ O.pgArray O.pgInt4 []) (== [[] :: [Int]])
 
 -- This test fails without the explicit cast in pgArray since postgres
--- defaults the text to 'text' but postgresql-simple expects 'citext'.
+-- defaults the numbers to 'integer' but postgresql-simple expects 'float8'.
 
-testCITextArray :: Test
-testCITextArray = testG (A.pure $ O.pgArray O.pgCiStrictText texts) (== [texts])
+testFloatArray :: Test
+testFloatArray = testG (A.pure $ O.pgArray O.pgDouble doubles) (== [doubles])
   where
-    texts = ["hello", "world"]
+    doubles = [1 :: Double, 2]
 
 allTests :: [Test]
 allTests = [testSelect, testProduct, testRestrict, testNum, testDiv, testCase,
@@ -694,7 +694,7 @@ allTests = [testSelect, testProduct, testRestrict, testNum, testDiv, testCase,
             testKeywordColNames, testInsertSerial, testInQuery, testAtTimeZone,
             testStringArrayAggregateOrdered, testMultipleAggregateOrdered,
             testOverwriteAggregateOrdered, testCountRows0, testCountRows3,
-            testArrayLiterals, testEmptyArray, testCITextArray
+            testArrayLiterals, testEmptyArray, testFloatArray
             ]
 
 -- Environment.getEnv throws an exception on missing environment variable!

--- a/Test/Test.hs
+++ b/Test/Test.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE Arrows #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE OverloadedStrings #-}
 
 module Main where
 
@@ -662,6 +663,24 @@ testAtTimeZone = testG (A.pure (O.timestamptzAtTimeZone t (O.pgString "CET"))) (
         t' = Time.LocalTime d (Time.TimeOfDay 2 0 0)
         d = Time.fromGregorian 2015 1 1
 
+testArrayLiterals :: Test
+testArrayLiterals = testG (A.pure $ O.pgArray O.pgInt4 vals) (== [vals])
+  where vals = [1,2,3]
+
+-- This test fails without the explicit cast in pgArray since postgres
+-- can't determine the type of the array.
+
+testEmptyArray :: Test
+testEmptyArray = testG (A.pure $ O.pgArray O.pgInt4 []) (== [[] :: [Int]])
+
+-- This test fails without the explicit cast in pgArray since postgres
+-- defaults the text to 'text' but postgresql-simple expects 'citext'.
+
+testCITextArray :: Test
+testCITextArray = testG (A.pure $ O.pgArray O.pgCiStrictText texts) (== [texts])
+  where
+    texts = ["hello", "world"]
+
 allTests :: [Test]
 allTests = [testSelect, testProduct, testRestrict, testNum, testDiv, testCase,
             testDistinct, testAggregate, testAggregate0, testAggregateFunction,
@@ -674,7 +693,8 @@ allTests = [testSelect, testProduct, testRestrict, testNum, testDiv, testCase,
             testValuesEmpty, testUnionAll, testTableFunctor, testUpdate,
             testKeywordColNames, testInsertSerial, testInQuery, testAtTimeZone,
             testStringArrayAggregateOrdered, testMultipleAggregateOrdered,
-            testOverwriteAggregateOrdered, testCountRows0, testCountRows3
+            testOverwriteAggregateOrdered, testCountRows0, testCountRows3,
+            testArrayLiterals, testEmptyArray, testCITextArray
             ]
 
 -- Environment.getEnv throws an exception on missing environment variable!

--- a/src/Opaleye/Column.hs
+++ b/src/Opaleye/Column.hs
@@ -1,12 +1,13 @@
 module Opaleye.Column (module Opaleye.Column,
                        Column,
                        Nullable,
+                       unsafeCast,
                        unsafeCoerce,
                        unsafeCoerceColumn,
                        unsafeCompositeField)  where
 
 import           Opaleye.Internal.Column (Column, Nullable, unsafeCoerce, unsafeCoerceColumn,
-                                          unsafeCompositeField)
+                                          unsafeCast, unsafeCompositeField)
 import qualified Opaleye.Internal.Column as C
 import qualified Opaleye.Internal.HaskellDB.PrimQuery as HPQ
 import qualified Opaleye.PGTypes as T
@@ -44,10 +45,3 @@ toNullable = unsafeCoerceColumn
 -- provided value coerced to a nullable type.
 maybeToNullable :: Maybe (Column a) -> Column (Nullable a)
 maybeToNullable = maybe null toNullable
-
--- | Cast a column to any other type. This is safe for some conversions such as uuid to text.
-unsafeCast :: String -> C.Column a -> Column b
-unsafeCast = mapColumn . HPQ.CastExpr
-  where
-    mapColumn :: (HPQ.PrimExpr -> HPQ.PrimExpr) -> Column c -> Column a
-    mapColumn primExpr c = C.Column (primExpr (C.unColumn c))

--- a/src/Opaleye/Constant.hs
+++ b/src/Opaleye/Constant.hs
@@ -105,7 +105,7 @@ instance D.Default Constant LBS.ByteString (Column T.PGJsonb) where
 instance D.Default Constant Ae.Value (Column T.PGJsonb) where
   def = Constant T.pgValueJSONB
 
-instance (D.Default Constant a (Column b), T.IsPGType b)
+instance (D.Default Constant a (Column b), T.IsSqlType b)
          => D.Default Constant [a] (Column (T.PGArray b)) where
   def = Constant (T.pgArray (constantExplicit D.def))
 

--- a/src/Opaleye/Constant.hs
+++ b/src/Opaleye/Constant.hs
@@ -105,6 +105,10 @@ instance D.Default Constant LBS.ByteString (Column T.PGJsonb) where
 instance D.Default Constant Ae.Value (Column T.PGJsonb) where
   def = Constant T.pgValueJSONB
 
+instance (D.Default Constant a (Column b), T.IsPGType b)
+         => D.Default Constant [a] (Column (T.PGArray b)) where
+  def = Constant (T.pgArray (constantExplicit D.def))
+
 -- { Boilerplate instances
 
 instance Functor (Constant a) where

--- a/src/Opaleye/Internal/Column.hs
+++ b/src/Opaleye/Internal/Column.hs
@@ -20,6 +20,13 @@ unsafeCoerce = unsafeCoerceColumn
 unsafeCoerceColumn :: Column a -> Column b
 unsafeCoerceColumn (Column e) = Column e
 
+-- | Cast a column to any other type. This is safe for some conversions such as uuid to text.
+unsafeCast :: String -> Column a -> Column b
+unsafeCast = mapColumn . HPQ.CastExpr
+  where
+    mapColumn :: (HPQ.PrimExpr -> HPQ.PrimExpr) -> Column c -> Column a
+    mapColumn primExpr c = Column (primExpr (unColumn c))
+
 unsafeCompositeField :: Column a -> String -> Column b
 unsafeCompositeField (Column e) fieldName =
   Column (HPQ.CompositeExpr e fieldName)

--- a/src/Opaleye/Internal/HaskellDB/PrimQuery.hs
+++ b/src/Opaleye/Internal/HaskellDB/PrimQuery.hs
@@ -32,6 +32,7 @@ data PrimExpr   = AttrExpr  Symbol
                                     -- TODO: I'm not sure this belongs
                                     -- here.  Perhaps a special type is
                                     -- needed for insert expressions.
+                | ArrayExpr [PrimExpr] -- ^ ARRAY[..]
                 deriving (Read,Show)
 
 data Literal = NullLit

--- a/src/Opaleye/Internal/HaskellDB/Sql.hs
+++ b/src/Opaleye/Internal/HaskellDB/Sql.hs
@@ -47,6 +47,7 @@ data SqlExpr = ColumnSqlExpr  SqlColumn
              | ParensSqlExpr SqlExpr
              | CastSqlExpr String SqlExpr
              | DefaultSqlExpr
+             | ArraySqlExpr [SqlExpr]
   deriving Show
 
 -- | Data type for SQL UPDATE statements.

--- a/src/Opaleye/Internal/HaskellDB/Sql/Default.hs
+++ b/src/Opaleye/Internal/HaskellDB/Sql/Default.hs
@@ -136,6 +136,7 @@ defaultSqlExpr gen expr =
       FunExpr n exprs  -> FunSqlExpr n (map (sqlExpr gen) exprs)
       CastExpr typ e1 -> CastSqlExpr typ (sqlExpr gen e1)
       DefaultInsertExpr -> DefaultSqlExpr
+      ArrayExpr es -> ArraySqlExpr (map (sqlExpr gen) es)
 
 showBinOp :: BinOp -> String
 showBinOp  OpEq         = "="

--- a/src/Opaleye/Internal/HaskellDB/Sql/Print.hs
+++ b/src/Opaleye/Internal/HaskellDB/Sql/Print.hs
@@ -26,7 +26,7 @@ import Data.List (intersperse)
 import qualified Data.List.NonEmpty as NEL
 import Text.PrettyPrint.HughesPJ (Doc, (<+>), ($$), (<>), comma, doubleQuotes,
                                   empty, equals, hcat, hsep, parens, punctuate,
-                                  text, vcat)
+                                  text, vcat, brackets)
 
 -- Silliness to avoid "ORDER BY 1" etc. meaning order by the first
 -- column.  We need an identity function, but due to
@@ -134,6 +134,7 @@ ppSqlExpr expr =
       PlaceHolderSqlExpr -> text "?"
       CastSqlExpr typ e -> text "CAST" <> parens (ppSqlExpr e <+> text "AS" <+> text typ)
       DefaultSqlExpr    -> text "DEFAULT"
+      ArraySqlExpr es -> text "ARRAY" <> brackets (commaH ppSqlExpr es)
 
 commaH :: (a -> Doc) -> [a] -> Doc
 commaH f = hcat . punctuate comma . map f

--- a/src/Opaleye/Operators.hs
+++ b/src/Opaleye/Operators.hs
@@ -151,3 +151,12 @@ timestamptzAtTimeZone :: Column T.PGTimestamptz
                       -> Column T.PGText
                       -> Column T.PGTimestamp
 timestamptzAtTimeZone = C.binOp HPQ.OpAtTimeZone
+
+emptyArray :: T.IsPGType a => Column (T.PGArray a)
+emptyArray = T.pgArray id []
+
+arrayPrepend :: Column a -> Column (T.PGArray a) -> Column (T.PGArray a)
+arrayPrepend (Column e) (Column es) = Column (HPQ.FunExpr "array_prepend" [e, es])
+
+singletonArray :: T.IsPGType a => Column a -> Column (T.PGArray a)
+singletonArray x = arrayPrepend x emptyArray

--- a/src/Opaleye/Operators.hs
+++ b/src/Opaleye/Operators.hs
@@ -152,11 +152,11 @@ timestamptzAtTimeZone :: Column T.PGTimestamptz
                       -> Column T.PGTimestamp
 timestamptzAtTimeZone = C.binOp HPQ.OpAtTimeZone
 
-emptyArray :: T.IsPGType a => Column (T.PGArray a)
+emptyArray :: T.IsSqlType a => Column (T.PGArray a)
 emptyArray = T.pgArray id []
 
 arrayPrepend :: Column a -> Column (T.PGArray a) -> Column (T.PGArray a)
 arrayPrepend (Column e) (Column es) = Column (HPQ.FunExpr "array_prepend" [e, es])
 
-singletonArray :: T.IsPGType a => Column a -> Column (T.PGArray a)
+singletonArray :: T.IsSqlType a => Column a -> Column (T.PGArray a)
 singletonArray x = arrayPrepend x emptyArray

--- a/src/Opaleye/PGTypes.hs
+++ b/src/Opaleye/PGTypes.hs
@@ -152,50 +152,50 @@ pgLazyJSONB = pgJSONB . IPT.lazyDecodeUtf8
 pgValueJSONB :: Ae.ToJSON a => a -> Column PGJsonb
 pgValueJSONB = pgLazyJSONB . Ae.encode
 
-pgArray :: forall a b. IsPGType b => (a -> C.Column b) -> [a] -> C.Column (PGArray b)
+pgArray :: forall a b. IsSqlType b => (a -> C.Column b) -> [a] -> C.Column (PGArray b)
 pgArray pgEl xs = C.unsafeCast arrayTy $
   C.Column (HPQ.ArrayExpr (map oneEl xs))
   where
     oneEl = C.unColumn . pgEl
     arrayTy = showPGType ([] :: [PGArray b])
 
-class IsPGType pgType where
+class IsSqlType pgType where
   showPGType :: proxy pgType -> String
-instance IsPGType PGBool where
+instance IsSqlType PGBool where
   showPGType _ = "boolean"
-instance IsPGType PGDate where
+instance IsSqlType PGDate where
   showPGType _ = "date"
-instance IsPGType PGFloat4 where
+instance IsSqlType PGFloat4 where
   showPGType _ = "real"
-instance IsPGType PGFloat8 where
+instance IsSqlType PGFloat8 where
   showPGType _ = "double precision"
-instance IsPGType PGInt8 where
+instance IsSqlType PGInt8 where
   showPGType _ = "bigint"
-instance IsPGType PGInt4 where
+instance IsSqlType PGInt4 where
   showPGType _ = "integer"
-instance IsPGType PGInt2 where
+instance IsSqlType PGInt2 where
   showPGType _ = "smallint"
-instance IsPGType PGNumeric where
+instance IsSqlType PGNumeric where
   showPGType _ = "numeric"
-instance IsPGType PGText where
+instance IsSqlType PGText where
   showPGType _ = "text"
-instance IsPGType PGTime where
+instance IsSqlType PGTime where
   showPGType _ = "time"
-instance IsPGType PGTimestamp where
+instance IsSqlType PGTimestamp where
   showPGType _ = "timestamp"
-instance IsPGType PGTimestamptz where
+instance IsSqlType PGTimestamptz where
   showPGType _ = "timestamp with time zone"
-instance IsPGType PGUuid where
+instance IsSqlType PGUuid where
   showPGType _ = "uuid"
-instance IsPGType PGCitext where
+instance IsSqlType PGCitext where
   showPGType _ =  "citext"
-instance IsPGType PGBytea where
+instance IsSqlType PGBytea where
   showPGType _ = "bytea"
-instance IsPGType a => IsPGType (PGArray a) where
+instance IsSqlType a => IsSqlType (PGArray a) where
   showPGType _ = showPGType ([] :: [a]) ++ "[]"
-instance IsPGType a => IsPGType (C.Nullable a) where
+instance IsSqlType a => IsSqlType (C.Nullable a) where
   showPGType _ = showPGType ([] :: [a])
-instance IsPGType PGJson where
+instance IsSqlType PGJson where
   showPGType _ = "json"
-instance IsPGType PGJsonb where
+instance IsSqlType PGJsonb where
   showPGType _ = "jsonb"


### PR DESCRIPTION
This add support for creating arrays in several ways:

* Directly with `pgArray`.
* Using `constant`.
* By manipulating them with `emptyArray`, `singletonArray` and `arrayPrepend`.

This adds an explicit type cast to every array literal, since it's been my experience that without it, many things don't work: empty arrays never work, and array contents tend to default (e.g. citext to text, numbers to int I think). To do this I created a type class `IsPGType` that allows printing the postgres type string from the haskell postgres type.

The one bit that is a little nasty is that `pgArray` takes a function to create the inner literal, and this has to be one of the functions creating a literal, but that's not enforced by the types. This could be fixed by having all those functions return a `Literal`, although it seems some return a cast instead (so with the current code arrays of date/times will not work). What do you think the nicest solution is here?