### PR TITLE
Add charLength function

### DIFF
--- a/src/Opaleye/Operators.hs
+++ b/src/Opaleye/Operators.hs
@@ -110,6 +110,9 @@ upper = C.unOp HPQ.OpUpper
 like :: Column T.PGText -> Column T.PGText -> Column T.PGBool
 like = C.binOp HPQ.OpLike
 
+charLength :: C.PGString a => Column a -> Column Int
+charLength (Column e) = Column (HPQ.FunExpr "char_length" [e])
+
 -- | True when any element of the container is true
 ors :: F.Foldable f => f (Column T.PGBool) -> Column T.PGBool
 ors = F.foldl' (.||) (T.pgBool False)

--- a/src/Opaleye/PGTypes.hs
+++ b/src/Opaleye/PGTypes.hs
@@ -55,6 +55,9 @@ instance C.PGFractional PGFloat8 where
 instance C.PGString PGText where
   pgFromString = pgString
 
+instance C.PGString PGCitext where
+  pgFromString = pgCiLazyText . CI.mk . LText.pack
+
 literalColumn :: HPQ.Literal -> Column a
 literalColumn = IPT.literalColumn
 {-# WARNING literalColumn


### PR DESCRIPTION
I chose to reuse the `PGString` class as a constraint to be able to restrict this to `PGText` and `PGCitext. If you would rather have a new type class for this, let me know.