### PR TITLE
Add quot_ and rem_.

### DIFF
--- a/src/Opaleye/Internal/Column.hs
+++ b/src/Opaleye/Internal/Column.hs
@@ -74,6 +74,8 @@ instance (PGNum a, PGFractional a) => Fractional (Column a) where
   fromRational = pgFromRational
   (/) = binOp HPQ.OpDiv
 
+class PGIntegral a
+
 class PGString a where
     pgFromString :: String -> Column a
 

--- a/src/Opaleye/Operators.hs
+++ b/src/Opaleye/Operators.hs
@@ -85,6 +85,12 @@ infix 4 .>=
 (.>=) :: Ord.PGOrd a => Column a -> Column a -> Column T.PGBool
 (.>=) = C.binOp HPQ.OpGtEq
 
+quot_ :: C.PGIntegral a => Column a -> Column a -> Column a
+quot_ = C.binOp HPQ.OpDiv
+
+rem_ :: C.PGIntegral a => Column a -> Column a -> Column a
+rem_ = C.binOp HPQ.OpMod
+
 case_ :: [(Column T.PGBool, Column a)] -> Column a -> Column a
 case_ = unsafeCase_
 

--- a/src/Opaleye/PGTypes.hs
+++ b/src/Opaleye/PGTypes.hs
@@ -52,6 +52,10 @@ instance C.PGNum PGInt8 where
 instance C.PGFractional PGFloat8 where
   pgFromRational = pgDouble . fromRational
 
+instance C.PGIntegral PGInt2
+instance C.PGIntegral PGInt4
+instance C.PGIntegral PGInt8
+
 instance C.PGString PGText where
   pgFromString = pgString
 


### PR DESCRIPTION
I made these applicable only to integral types, since that mirrors what Haskell does, and the behavior is different: `(5::integer) / 2 == 2`, whereas (5 :: float) / 2 == 2.5. However, the underlying postgres operators work on any numeric type, so let me know if you want me to change that.