### PR TITLE
Expose fieldParserQueryRunnerColumn from Opaleye.RunQuery.

### DIFF
--- a/src/Opaleye/RunQuery.hs
+++ b/src/Opaleye/RunQuery.hs
@@ -4,7 +4,8 @@ module Opaleye.RunQuery (module Opaleye.RunQuery,
                          QueryRunner,
                          IRQ.QueryRunnerColumn,
                          IRQ.QueryRunnerColumnDefault (..),
-                         IRQ.fieldQueryRunnerColumn) where
+                         IRQ.fieldQueryRunnerColumn,
+                         IRQ.fieldParserQueryRunnerColumn) where
 
 import qualified Database.PostgreSQL.Simple as PGS
 import qualified Database.PostgreSQL.Simple.FromRow as FR


### PR DESCRIPTION
This exposes [`fieldParserQueryRunnerColumn`](https://github.com/tomjaguarpaw/haskell-opaleye/blob/c5b3c06ab64d76be17871d2a14909f440d86f006/src/Opaleye/Internal/RunQuery.hs#L90) from `Opaleye.RunQuery`.

`fieldParserQueryRunnerColumn` lets you specify the `FieldParser` you want to use when producing a `QueryRunnerColumn`.

```
fieldParserQueryRunnerColumn :: FieldParser haskell -> QueryRunnerColumn coltype haskell
```

As we [discussed](https://github.com/tomjaguarpaw/haskell-opaleye/pull/157#issuecomment-214377139) in #157, users should be able to use `fieldParserQueryRunnerColumn` to define instances of `QueryRunnerColumnDefault`.