### PR TITLE
Adding documentation on constant function explaining how to insert custom types into the database.

### DIFF
--- a/src/Opaleye/Constant.hs
+++ b/src/Opaleye/Constant.hs
@@ -28,6 +28,24 @@ import           Data.Functor                    ((<$>))
 newtype Constant haskells columns =
   Constant { constantExplicit :: haskells -> columns }
 
+-- | 'constant' can be used with functions like
+-- 'Opaleye.Manipulation.runInsert' to insert custom Haskell types into the
+-- database.
+--
+-- The following is an example of a function for inserting custom types.
+--
+-- @
+--   customInsert
+--      :: ( 'D.Default' 'Constant' haskells columns )
+--      => Connection
+--      -> 'Opaleye.Table' columns columns'
+--      -> haskells
+--      -> IO Int64
+--   customInsert conn table haskells = 'Opaleye.Manipulation.runInsert' conn table $ 'constant' haskells
+-- @
+--
+-- In order to use this function with your custom types, you need to define an
+-- instance of 'D.Default' 'Constant' for your custom types.
 constant :: D.Default Constant haskells columns
          => haskells -> columns
 constant = constantExplicit D.def


### PR DESCRIPTION
This PR adds some documentation to the `constant` function explaining how to use it to insert custom types into the database as per https://github.com/tomjaguarpaw/haskell-opaleye/pull/157#issuecomment-215823546.

I don't think my explanation in the comment is really that great, so let me know if there is anything that should be changed.