### PR TITLE
Remove unnecessary code duplication for the PGArray parser.

### DIFF
--- a/src/Opaleye/Internal/RunQuery.hs
+++ b/src/Opaleye/Internal/RunQuery.hs
@@ -2,13 +2,15 @@
 
 module Opaleye.Internal.RunQuery where
 
-import           Control.Applicative (Applicative, pure, (*>), (<*>), liftA2)
+import           Control.Applicative (liftA2)
 
 import           Database.PostgreSQL.Simple.Internal (RowParser)
-import           Database.PostgreSQL.Simple.FromField (FieldParser, FromField,
-                                                       fromField)
+import           Database.PostgreSQL.Simple.FromField
+  ( FieldParser, FromField, ResultError(UnexpectedNull, Incompatible)
+  , fromField, pgArrayFieldParser, typeInfo, returnError)
 import           Database.PostgreSQL.Simple.FromRow (fromRow, fieldWith)
 import           Database.PostgreSQL.Simple.Types (fromPGArray, Only(..))
+import qualified Database.PostgreSQL.Simple.TypeInfo as TI
 
 import           Opaleye.Column (Column)
 import           Opaleye.Internal.Column (Nullable)
@@ -32,25 +34,10 @@ import qualified Data.ByteString as SBS
 import qualified Data.ByteString.Lazy as LBS
 import qualified Data.Time as Time
 import qualified Data.String as String
+import           Data.Typeable (Typeable)
 import           Data.UUID (UUID)
 import           GHC.Int (Int32, Int64)
 
--- { Only needed for annoying postgresql-simple patch below
-
-import           Control.Applicative ((<$>))
-import           Database.PostgreSQL.Simple.FromField
-  (Field, typoid, typeOid, typelem, TypeInfo,
-   ResultError(UnexpectedNull, ConversionFailed, Incompatible),
-   typdelim, typeInfo, returnError, Conversion)
-import           Database.PostgreSQL.Simple.Types (PGArray(PGArray))
-import           Data.Attoparsec.ByteString.Char8 (Parser, parseOnly)
-import qualified Database.PostgreSQL.Simple.TypeInfo as TI
-import qualified Database.PostgreSQL.Simple.Arrays as Arrays
-import           Database.PostgreSQL.Simple.Arrays (array, fmt)
-import           Data.String (fromString)
-import           Data.Typeable (Typeable)
-
--- }
 
 -- | A 'QueryRunnerColumn' @pgType@ @haskellType@ encodes how to turn
 -- a value of Postgres type @pgType@ into a value of Haskell type
@@ -212,7 +199,7 @@ arrayColumn = C.unsafeCoerceColumn
 
 instance (Typeable b, QueryRunnerColumnDefault a b) =>
          QueryRunnerColumnDefault (T.PGArray a) [b] where
-  queryRunnerColumnDefault = QueryRunnerColumn (P.lmap arrayColumn c) ((fmap . fmap . fmap) fromPGArray (arrayFieldParser f))
+  queryRunnerColumnDefault = QueryRunnerColumn (P.lmap arrayColumn c) ((fmap . fmap . fmap) fromPGArray (pgArrayFieldParser f))
     where QueryRunnerColumn c f = queryRunnerColumnDefault
 
 -- }
@@ -244,39 +231,6 @@ instance PP.SumProfunctor QueryRunner where
                          (either fb gb)
     where QueryRunner fu fr fb = f
           QueryRunner gu gr gb = g
-
--- }
-
--- { Annoying postgresql-simple patch.  Delete this when it is merged upstream.
-
-arrayFieldParser :: Typeable a => FieldParser a -> FieldParser (PGArray a)
-arrayFieldParser
-    fieldParser f mdat = do
-        info <- typeInfo f
-        case info of
-          TI.Array{} ->
-              case mdat of
-                Nothing  -> returnError UnexpectedNull f ""
-                Just dat -> do
-                   case parseOnly (fromArray fieldParser info f) dat of
-                     Left  err  -> returnError ConversionFailed f err
-                     Right conv -> PGArray <$> conv
-          _ -> returnError Incompatible f ""
-
-fromArray :: FieldParser a -> TypeInfo -> Field -> Parser (Conversion [a])
-fromArray fieldParser tInfo f = sequence . (parseIt <$>) <$> array delim
-  where
-    delim = typdelim (typelem tInfo)
-    fElem = f{ typeOid = typoid (typelem tInfo) }
-
-    parseIt item =
-        fieldParser f' $ if item' == fromString "NULL" then Nothing else Just item'
-      where
-        item' = fmt delim item
-        f' | Arrays.Array _ <- item = f
-           | otherwise              = fElem
-
--- }
 
 -- { Allow @postgresql-simple@ conversions from JSON types to 'String'
 


### PR DESCRIPTION
This commit will avoid the code to get out of sync with postgresql-simple (for instance , there is a up coming [bug fix](https://github.com/lpsmith/postgresql-simple/pull/189))
