### PR TITLE
Opaleye: generate valid sql with 0 CASE alternatives.

### DIFF
--- a/Test/Test.hs
+++ b/Test/Test.hs
@@ -334,6 +334,16 @@ testCase = testG q (== expected)
         expected :: [Int]
         expected = [12, 12, 21, 33]
 
+-- This tests case_ with an empty list of cases, to make sure it generates valid
+-- SQL.
+testCaseEmpty :: Test
+testCaseEmpty = testG q (== expected)
+  where q :: Query (Column O.PGInt4)
+        q = table1Q >>> proc _ ->
+          Arr.returnA -< O.case_ [] 33
+        expected :: [Int]
+        expected = [33, 33, 33, 33]
+
 testDistinct :: Test
 testDistinct = testG (O.distinct table1Q)
                (\r -> L.sort (L.nub table1data) == L.sort r)
@@ -694,7 +704,7 @@ allTests = [testSelect, testProduct, testRestrict, testNum, testDiv, testCase,
             testKeywordColNames, testInsertSerial, testInQuery, testAtTimeZone,
             testStringArrayAggregateOrdered, testMultipleAggregateOrdered,
             testOverwriteAggregateOrdered, testCountRows0, testCountRows3,
-            testArrayLiterals, testEmptyArray, testFloatArray
+            testArrayLiterals, testEmptyArray, testFloatArray, testCaseEmpty
             ]
 
 -- Environment.getEnv throws an exception on missing environment variable!

--- a/src/Opaleye/Internal/HaskellDB/Sql/Print.hs
+++ b/src/Opaleye/Internal/HaskellDB/Sql/Print.hs
@@ -125,8 +125,11 @@ ppSqlExpr expr =
       FunSqlExpr f es     -> text f <> parens (commaH ppSqlExpr es)
       AggrFunSqlExpr f es ord -> text f <> parens (commaH ppSqlExpr es <+> ppOrderBy ord)
       ConstSqlExpr c      -> text c
-      CaseSqlExpr cs el   -> text "CASE" <+> vcat (map ppWhen cs)
-                             <+> text "ELSE" <+> ppSqlExpr el <+> text "END"
+      CaseSqlExpr cs el   ->
+          if null cs
+          then ppSqlExpr el
+          else text "CASE" <+> vcat (map ppWhen cs)
+               <+> text "ELSE" <+> ppSqlExpr el <+> text "END"
           where ppWhen (w,t) = text "WHEN" <+> ppSqlExpr w
                                <+> text "THEN" <+> ppSqlExpr t
       ListSqlExpr es      -> parens (commaH ppSqlExpr es)


### PR DESCRIPTION
I ran into this when dynamically generating the list of case alternatives, and there happened to be 0 at some point.