### PR TITLE
defaultSqlExpr: Fix handling of `BinExpr OpIn _ (ListExpr _)`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## HEAD
+
+* Fixed handling of `BinExpr OpIn _ (ListExpr _)` in `defaultSqlExpr`.
+
 ## 0.5.1.0
 
 * Added

--- a/src/Opaleye/Internal/HaskellDB/Sql/Default.hs
+++ b/src/Opaleye/Internal/HaskellDB/Sql/Default.hs
@@ -100,6 +100,8 @@ defaultSqlExpr gen expr =
                 (paren leftE, rightE)
               (OpOr, _, BinExpr OpAnd _ _) ->
                 (leftE, paren rightE)
+              (OpIn, _, ListExpr _) ->
+                (leftE, rightE)
               (_, ConstExpr _, ConstExpr _) ->
                 (leftE, rightE)
               (_, _, ConstExpr _) ->


### PR DESCRIPTION
There's an issue in how `BinExpr OpIn _ (ListExpr _)` expressions are
currently handled in `defaultSqlExpr`. For example, consider this
`PrimExpr`:

```haskell
pe1 :: PrimExpr
pe1 = BinExpr OpIn
              (ConstExpr (BoolLit True))
              (ListExpr [ConstExpr (BoolLit True),
                         ConstExpr (BoolLit False)])
```

Before this change, we get redundant parentheses, which makes PostgreSQL
treat `((TRUE,FALSE))` as a list of records, instead of a list of
booleans as expected:

```
> ppSqlExpr (defaultSqlExpr defaultSqlGenerator pe1)
TRUE IN ((TRUE,FALSE))
```

After this change, we get the list of booleans as expected:

```haskell
> ppSqlExpr (defaultSqlExpr defaultSqlGenerator pe1)
TRUE IN (TRUE,FALSE)
```