### PR TITLE
Opaleye.Operators.in_ now actually uses the SQL `IN` operator.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## HEAD
+
+* Fixed handling of `BinExpr OpIn _ (ListExpr _)` in `defaultSqlExpr`.
+
 ## 0.5.1.0
 
 * Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## HEAD
 
 * Fixed handling of `BinExpr OpIn _ (ListExpr _)` in `defaultSqlExpr`.
+* `in_` now actually uses the SQL `IN` operator.
 
 ## 0.5.1.0
 

--- a/Test/Test.hs
+++ b/Test/Test.hs
@@ -346,6 +346,16 @@ testRestrict = testG query
           O.restrict -< fst t .== 1
           Arr.returnA -< t
 
+testIn :: Test
+testIn = testG query expected
+  where query = proc () -> do
+          t <- table1Q -< ()
+          O.restrict -< O.in_ [O.pgInt4 100, O.pgInt4 200] (snd t)
+          O.restrict -< O.not (O.in_ [] (fst t)) -- Making sure empty lists work.
+          Arr.returnA -< t
+        expected = \r ->
+          filter (flip elem [100, 200] . snd) (L.sort table1data) == L.sort r
+
 testNum :: Test
 testNum = testG query expected
   where query :: Query (Column O.PGInt4)
@@ -835,7 +845,7 @@ allTests = [testSelect, testProduct, testRestrict, testNum, testDiv, testCase,
             testDistinct, testAggregate, testAggregate0, testAggregateFunction,
             testAggregateProfunctor, testStringArrayAggregate, testStringAggregate,
             testOrderBy, testOrderBy2, testOrderBySame, testLimit, testOffset,
-            testLimitOffset, testOffsetLimit, testDistinctAndAggregate,
+            testLimitOffset, testOffsetLimit, testDistinctAndAggregate, testIn,
             testDoubleDistinct, testDoubleAggregate, testDoubleLeftJoin,
             testDoubleValues, testDoubleUnionAll,
             testLeftJoin, testLeftJoinNullable, testThreeWayProduct, testValues,

--- a/opaleye.cabal
+++ b/opaleye.cabal
@@ -13,7 +13,7 @@ author:          Purely Agile
 maintainer:      Purely Agile
 category:        Database
 build-type:      Simple
-cabal-version:   >= 1.10
+cabal-version:   >= 1.18
 extra-doc-files: *.md,
                  Doc/*.md
 tested-with:     GHC==7.10.1, GHC==7.8.4, GHC==7.6.3

--- a/src/Opaleye/Internal/HaskellDB/PrimQuery.hs
+++ b/src/Opaleye/Internal/HaskellDB/PrimQuery.hs
@@ -6,6 +6,7 @@ module Opaleye.Internal.HaskellDB.PrimQuery where
 
 import qualified Opaleye.Internal.Tag as T
 import Data.ByteString (ByteString)
+import qualified Data.List.NonEmpty as NEL
 
 type TableName  = String
 type Attribute  = String
@@ -23,7 +24,7 @@ data PrimExpr   = AttrExpr  Symbol
                 | AggrExpr  AggrOp PrimExpr [OrderExpr]
                 | ConstExpr Literal
                 | CaseExpr [(PrimExpr,PrimExpr)] PrimExpr
-                | ListExpr [PrimExpr]
+                | ListExpr (NEL.NonEmpty PrimExpr)
                 | ParamExpr (Maybe Name) PrimExpr
                 | FunExpr Name [PrimExpr]
                 | CastExpr Name PrimExpr -- ^ Cast an expression to a given type.

--- a/src/Opaleye/Internal/HaskellDB/Sql.hs
+++ b/src/Opaleye/Internal/HaskellDB/Sql.hs
@@ -41,7 +41,7 @@ data SqlExpr = ColumnSqlExpr  SqlColumn
              | AggrFunSqlExpr String [SqlExpr] [(SqlExpr, SqlOrder)] -- ^ Aggregate functions separate from normal functions.
              | ConstSqlExpr   String
              | CaseSqlExpr    (NEL.NonEmpty (SqlExpr,SqlExpr)) SqlExpr
-             | ListSqlExpr    [SqlExpr]
+             | ListSqlExpr    (NEL.NonEmpty SqlExpr)
              | ParamSqlExpr (Maybe SqlName) SqlExpr
              | PlaceHolderSqlExpr
              | ParensSqlExpr SqlExpr

--- a/src/Opaleye/Internal/HaskellDB/Sql/Default.hs
+++ b/src/Opaleye/Internal/HaskellDB/Sql/Default.hs
@@ -135,7 +135,7 @@ defaultSqlExpr gen expr =
                           in case NEL.nonEmpty cs' of
                             Just nel -> CaseSqlExpr nel e'
                             Nothing  -> e'
-      ListExpr es      -> ListSqlExpr (map (sqlExpr gen) es)
+      ListExpr es      -> ListSqlExpr (fmap (sqlExpr gen) es)
       ParamExpr n _    -> ParamSqlExpr n PlaceHolderSqlExpr
       FunExpr n exprs  -> FunSqlExpr n (map (sqlExpr gen) exprs)
       CastExpr typ e1 -> CastSqlExpr typ (sqlExpr gen e1)

--- a/src/Opaleye/Internal/HaskellDB/Sql/Default.hs
+++ b/src/Opaleye/Internal/HaskellDB/Sql/Default.hs
@@ -100,6 +100,8 @@ defaultSqlExpr gen expr =
                 (paren leftE, rightE)
               (OpOr, _, BinExpr OpAnd _ _) ->
                 (leftE, paren rightE)
+              (OpIn, _, ListExpr _) ->
+                (leftE, rightE)
               (_, ConstExpr _, ConstExpr _) ->
                 (leftE, rightE)
               (_, _, ConstExpr _) ->

--- a/src/Opaleye/Internal/HaskellDB/Sql/Print.hs
+++ b/src/Opaleye/Internal/HaskellDB/Sql/Print.hs
@@ -130,7 +130,7 @@ ppSqlExpr expr =
                              <+> text "ELSE" <+> ppSqlExpr el <+> text "END"
           where ppWhen (w,t) = text "WHEN" <+> ppSqlExpr w
                                <+> text "THEN" <+> ppSqlExpr t
-      ListSqlExpr es      -> parens (commaH ppSqlExpr es)
+      ListSqlExpr es      -> parens (commaH ppSqlExpr (NEL.toList es))
       ParamSqlExpr _ v -> ppSqlExpr v
       PlaceHolderSqlExpr -> text "?"
       CastSqlExpr typ e -> text "CAST" <> parens (ppSqlExpr e <+> text "AS" <+> text typ)

--- a/src/Opaleye/Operators.hs
+++ b/src/Opaleye/Operators.hs
@@ -9,6 +9,7 @@ module Opaleye.Operators (module Opaleye.Operators,
 
 import qualified Control.Arrow as A
 import qualified Data.Foldable as F
+import qualified Data.List.NonEmpty as NEL
 
 import           Opaleye.Internal.Column (Column(Column), unsafeCase_,
                                           unsafeIfThenElse, unsafeGt)
@@ -132,9 +133,9 @@ ors = F.foldl' (.||) (T.pgBool False)
 -- product.  'in_' @validProducts@ is a function which checks whether
 -- a product is a valid product.
 in_ :: (Functor f, F.Foldable f) => f (Column a) -> Column a -> Column T.PGBool
-in_ fcas (Column a) = Column $ case F.toList fcas of
-   [] -> HPQ.ConstExpr (HPQ.BoolLit False)
-   xs -> HPQ.BinExpr HPQ.OpIn a (HPQ.ListExpr (map C.unColumn xs))
+in_ fcas (Column a) = Column $ case NEL.nonEmpty (F.toList fcas) of
+   Nothing -> HPQ.ConstExpr (HPQ.BoolLit False)
+   Just xs -> HPQ.BinExpr HPQ.OpIn a (HPQ.ListExpr (fmap C.unColumn xs))
 
 -- | True if the first argument occurs amongst the rows of the second,
 -- false otherwise.


### PR DESCRIPTION
This change (a0828ba3caff6a14835fd06fba89863c9954e53e) is backwards compatible, and builds on top of #208.

Example: Using `in_` with a non-empty foldable uses `OpIn`.

```haskell
> in_ [pgBool True, pgBool False] (pgBool True)
Column (BinExpr OpIn
                (ConstExpr (BoolLit True))
                (ListExpr [ConstExpr (BoolLit True),
                           ConstExpr (BoolLit False)]))
```

Example: Using `in_` with an empty foldable is just `False`.

```haskell
> in_ [] (pgBool True)
Column (ConstExpr (BoolLit False))
```

A test named `testIn` was added to ensure `in_` behaves as expected,
both when given empty and non-empty `Foldable`s. The SQL output of the
query in the test is:

```sql
SELECT "column10_1" as "result1_2",
       "column21_1" as "result2_2"
FROM (SELECT *
      FROM (SELECT "column1" as "column10_1",
                   "column2" as "column21_1"
            FROM "table1" as "T1") as "T1"
      WHERE (NOT (FALSE)) AND ("column21_1" IN (100,200))) as "T1"
```