### PR TITLE
Tests: allow specifying the env variable OPALEYE_TEST_PG_CONN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 * Fixed handling of `BinExpr OpIn _ (ListExpr _)` in `defaultSqlExpr`.
 * `in_` now actually uses the SQL `IN` operator.
+* Tests: Allow specifing the PostgreSQL connection string via the
+  `OPALEYE_TEST_PG_CONN` environment variable.
 
 ## 0.5.1.0
 

--- a/opaleye.cabal
+++ b/opaleye.cabal
@@ -101,6 +101,7 @@ test-suite test
   build-depends:
     aeson >= 0.6 && < 0.12,
     base >= 4 && < 5,
+    bytestring,
     containers,
     contravariant,
     multiset,


### PR DESCRIPTION
Currently, running the test suite is a rather painful experience because one has to modify the `Test/Test.hs` every time in order to specify the PostgreSQL connection details (and then undo those changes before pushing anything upstream, in case one is making changes to the tests themselves). 

This is a backwards compatible change that allows specifying the `OPALEYE_TEST_PG_CONN` environment variable when running the tests, where one can specify the correct PostgreSQL connection string to use.

Example usage:

``` bash
OPALEYE_TEST_PG_CONN=postgresql://opa:opa@localhost/opa-test runghc ./Setup.hs test
```

If `OPALEYE_TEST_PG_CONN` is not specified, then the behavior is the same as it was before: Use the Travis CI settings if running in Travis CI, otherwise use the fallback defaults that are hardcoded in the `Test/Test.hs` file.
