### PR TITLE
Extract test configuration to yml

### DIFF
--- a/Test/Test.hs
+++ b/Test/Test.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE Arrows #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE OverloadedStrings #-}
-
+{-# LANGUAGE DeriveGeneric #-}
 module Main where
 
 import qualified QuickCheck
@@ -20,6 +20,7 @@ import           Data.Monoid ((<>))
 import qualified Data.String as String
 import qualified Data.Time   as Time
 import qualified Data.Aeson as Json
+import qualified Data.Yaml  as Yaml
 import qualified Data.Text as T
 
 import qualified System.Exit as Exit
@@ -29,27 +30,48 @@ import           Control.Applicative ((<$>), (<*>))
 import qualified Control.Applicative as A
 import qualified Control.Arrow as Arr
 import           Control.Arrow ((&&&), (***), (<<<), (>>>))
+import           Control.Exception.Base (throw)
+import           Control.Monad (when)
 
 import           GHC.Int (Int64)
-
+import           GHC.Word  (Word16)
+import           GHC.Generics
 -- { Set your test database info here.  Then invoke the 'main'
 --   function to run the tests, or just use 'cabal test'.  The test
 --   database must already exist and the test user must have
 --   permissions to modify it.
 
-connectInfo :: PGS.ConnectInfo
-connectInfo =  PGS.ConnectInfo { PGS.connectHost = "localhost"
-                               , PGS.connectPort = 25433
-                               , PGS.connectUser = "tom"
-                               , PGS.connectPassword = "tom"
-                               , PGS.connectDatabase = "opaleye_test" }
+data Configuration = Configuration
+                   { connectHost :: String
+                   , connectPort :: GHC.Word.Word16
+                   , connectUser :: String
+                   , connectPassword :: String
+                   , connectDatabase :: String
+                   , quickcheck :: Bool
+                   } deriving (Generic)
 
-connectInfoTravis :: PGS.ConnectInfo
-connectInfoTravis =  PGS.ConnectInfo { PGS.connectHost = "localhost"
-                                     , PGS.connectPort = 5432
-                                     , PGS.connectUser = "postgres"
-                                     , PGS.connectPassword = ""
-                                     , PGS.connectDatabase = "opaleye_test" }
+instance Yaml.FromJSON Configuration
+
+config2ConnInfo :: Configuration -> PGS.ConnectInfo
+config2ConnInfo c = PGS.ConnectInfo { PGS.connectHost = connectHost c
+                                    , PGS.connectPort = connectPort c
+                                    , PGS.connectUser = connectUser c
+                                    , PGS.connectPassword = connectPassword c
+                                    , PGS.connectDatabase = connectDatabase c
+                                    }
+
+config :: IO (Either Yaml.ParseException Configuration)
+config = Yaml.decodeFileEither "config.yml"
+
+configTravis :: IO (Either Yaml.ParseException Configuration)
+configTravis = return . return $
+                    Configuration { connectHost = "localhost"
+                                  , connectPort = 5432
+                                  , connectUser = "postgres"
+                                  , connectPassword = ""
+                                  , connectDatabase = "opaleye_test"
+                                  , quickcheck = True
+                                  }
 
 -- }
 
@@ -892,9 +914,12 @@ main :: IO ()
 main = do
   travis' <- travis
 
-  let connectInfo' = if travis' then connectInfoTravis else connectInfo
+  parsedConf <- if travis' then configTravis else config
+  config' <- case parsedConf of
+    Right conf -> return conf
+    Left err   -> throw err
 
-  conn <- PGS.connect connectInfo'
+  conn <- PGS.connect (config2ConnInfo config')
 
   dropAndCreateDB conn
 
@@ -912,7 +937,7 @@ main = do
   -- insert (table9, table9columndata)
 
   -- Need to run quickcheck after table data has been inserted
-  QuickCheck.run conn
+  when (quickcheck config') (QuickCheck.run conn)
 
   results <- mapM ($ conn) allTests
 

--- a/config.travis.yml
+++ b/config.travis.yml
@@ -1,0 +1,5 @@
+connectHost: "localhost"
+connectPort: 5432
+connectUser: postgres
+connectPassword: ""
+connectDatabase: opaleye_test

--- a/config.yml
+++ b/config.yml
@@ -1,0 +1,6 @@
+connectHost: "localhost"
+connectPort: 5432
+connectUser: postgres
+connectPassword: ""
+connectDatabase: opaleye_test
+quickcheck: true

--- a/opaleye.cabal
+++ b/opaleye.cabal
@@ -111,7 +111,8 @@ test-suite test
     semigroups,
     text >= 0.11 && < 1.3,
     time,
-    opaleye
+    opaleye,
+    yaml
   ghc-options: -Wall
 
 test-suite tutorial


### PR DESCRIPTION
In order to make testing in different environments simpler, I've extracted the configuration for tests to external YML files. This lets me more easily change my configuration to run tests locally. 

I'll probably completely remove `config.yml` and only provide `config.default.yml` as an example configuration while adding `config.yml` to `.gitignore`. 

I'm not quite sure why travis can't seem to find `config.travis.yml`, running tests locally with `TRAVIS=yes` doesn't seem to cause any issues.

Ah it seems like the CI script builds the code into a different directory but doesnt include the configuration file. I guess the proper solution would be something similar to `dotenv`. 