### PR TITLE
Hspec tests

### DIFF
--- a/Test/Test.hs
+++ b/Test/Test.hs
@@ -33,6 +33,7 @@ import           Control.Arrow ((&&&), (***), (<<<), (>>>))
 
 import           GHC.Int (Int64)
 
+import Test.Hspec
 -- { Set your test database info here.  Then invoke the 'main'
 --   function to run the tests, or just use 'cabal test'.  The test
 --   database must already exist and the test user must have
@@ -319,61 +320,62 @@ dropAndCreateDB conn = do
         executeJson = PGS.execute_ conn . dropAndCreateTableJson
         -- executeJsonb = PGS.execute_ conn . dropAndCreateTableJsonb
 
-type Test = PGS.Connection -> IO Bool
+type Test = SpecWith PGS.Connection
 
-testG :: D.Default O.QueryRunner wires haskells =>
+testH :: D.Default O.QueryRunner wires haskells =>
          Query wires
-         -> ([haskells] -> b)
+         -> ([haskells] -> IO expectation)
          -> PGS.Connection
-         -> IO b
-testG q p conn = do
+         -> IO expectation
+
+testH q p conn = do
   result <- O.runQuery conn q
-  return (p result)
+  p result
+
+queryShouldReturnSorted :: (D.Default O.QueryRunner wires haskells, Show haskells, Ord haskells) =>
+         Query wires
+         -> [haskells]
+         -> PGS.Connection
+         -> Expectation
+queryShouldReturnSorted q expected conn = testH q (\res -> L.sort res `shouldBe` L.sort expected) conn
 
 testSelect :: Test
-testSelect = testG table1Q
-             (\r -> L.sort table1data == L.sort r)
+testSelect = it "selects" $ table1Q `queryShouldReturnSorted` table1data
 
 testProduct :: Test
-testProduct = testG query
-                 (\r -> L.sort (A.liftA2 (,) table1data table2data) == L.sort r)
+testProduct = it "joins tables" $ query `queryShouldReturnSorted` (A.liftA2 (,) table1data table2data)
   where query = table1Q &&& table2Q
 
 testRestrict :: Test
-testRestrict = testG query
-               (\r -> filter ((== 1) . fst) (L.sort table1data) == L.sort r)
+testRestrict = it "restricts the rows returned" $ query `queryShouldReturnSorted` filter ((== 1) . fst) (L.sort table1data)
   where query = proc () -> do
           t <- table1Q -< ()
           O.restrict -< fst t .== 1
           Arr.returnA -< t
 
 testIn :: Test
-testIn = testG query expected
+testIn = it "restricts values to a range" $ query `queryShouldReturnSorted` filter (flip elem [100, 200] . snd) (L.sort table1data)
   where query = proc () -> do
           t <- table1Q -< ()
           O.restrict -< O.in_ [O.pgInt4 100, O.pgInt4 200] (snd t)
           O.restrict -< O.not (O.in_ [] (fst t)) -- Making sure empty lists work.
           Arr.returnA -< t
-        expected = \r ->
-          filter (flip elem [100, 200] . snd) (L.sort table1data) == L.sort r
 
 testNum :: Test
-testNum = testG query expected
+testNum = it "" $ query `queryShouldReturnSorted` (map op table1data)
   where query :: Query (Column O.PGInt4)
         query = proc () -> do
           t <- table1Q -< ()
           Arr.returnA -< op t
-        expected = \r -> L.sort (map op table1data) == L.sort r
         op :: Num a => (a, a) -> a
         op (x, y) = abs (x - 5) * signum (x - 4) * (y * y + 1)
 
 testDiv :: Test
-testDiv = testG query expected
+testDiv = it "" $ query `queryShouldReturnSorted` (map (op . toDoubles) table1data)
   where query :: Query (Column O.PGFloat8)
         query = proc () -> do
           t <- Arr.arr (O.doubleOfInt *** O.doubleOfInt) <<< table1Q -< ()
           Arr.returnA -< op t
-        expected r = L.sort (map (op . toDoubles) table1data) == L.sort r
         op :: Fractional a => (a, a) -> a
         -- Choosing 0.5 here as it should be exactly representable in
         -- floating point
@@ -383,7 +385,7 @@ testDiv = testG query expected
 
 -- TODO: need to implement and test case_ returning tuples
 testCase :: Test
-testCase = testG q (== expected)
+testCase = it "" $ q `queryShouldReturnSorted` expected
   where q :: Query (Column O.PGInt4)
         q = table1Q >>> proc (i, j) -> do
           Arr.returnA -< O.case_ [(j .== 100, 12), (i .== 1, 21)] 33
@@ -393,7 +395,7 @@ testCase = testG q (== expected)
 -- This tests case_ with an empty list of cases, to make sure it generates valid
 -- SQL.
 testCaseEmpty :: Test
-testCaseEmpty = testG q (== expected)
+testCaseEmpty = it "" $ q `queryShouldReturnSorted` expected
   where q :: Query (Column O.PGInt4)
         q = table1Q >>> proc _ ->
           Arr.returnA -< O.case_ [] 33
@@ -401,8 +403,7 @@ testCaseEmpty = testG q (== expected)
         expected = [33, 33, 33, 33]
 
 testDistinct :: Test
-testDistinct = testG (O.distinct table1Q)
-               (\r -> L.sort (L.nub table1data) == L.sort r)
+testDistinct = it "" $ O.distinct table1Q `queryShouldReturnSorted` (L.nub table1data)
 
 -- FIXME: the unsafeCoerceColumn is currently needed because the type
 -- changes required for aggregation are not currently dealt with by
@@ -414,137 +415,130 @@ aggregateCoerceFIXME' :: Column a -> Column O.PGInt8
 aggregateCoerceFIXME' = O.unsafeCoerceColumn
 
 testAggregate :: Test
-testAggregate = testG (Arr.second aggregateCoerceFIXME
+testAggregate = it "" $ (Arr.second aggregateCoerceFIXME
                         <<< O.aggregate (PP.p2 (O.groupBy, O.sum))
-                                           table1Q)
-                      (\r -> [(1, 400) :: (Int, Int64), (2, 300)] == L.sort r)
+                                           table1Q) `queryShouldReturnSorted` [(1, 400) :: (Int, Int64), (2, 300)]
 
 testAggregate0 :: Test
-testAggregate0 = testG (Arr.second aggregateCoerceFIXME
+testAggregate0 = it "" $ (Arr.second aggregateCoerceFIXME
                         <<< O.aggregate (PP.p2 (O.sum, O.sum))
                                         (O.keepWhen (const (O.pgBool False))
-                                         <<< table1Q))
-                      (== ([] :: [(Int, Int64)]))
+                                         <<< table1Q)) `queryShouldReturnSorted` ([] :: [(Int, Int64)])
 
 testAggregateFunction :: Test
-testAggregateFunction = testG (Arr.second aggregateCoerceFIXME
+testAggregateFunction = it "" $ (Arr.second aggregateCoerceFIXME
                         <<< O.aggregate (PP.p2 (O.groupBy, O.sum))
                                         (fmap (\(x, y) -> (x + 1, y)) table1Q))
-                      (\r -> [(2, 400) :: (Int, Int64), (3, 300)] == L.sort r)
+                      `queryShouldReturnSorted` [(2, 400) :: (Int, Int64), (3, 300)]
 
 testAggregateProfunctor :: Test
-testAggregateProfunctor = testG q expected
+testAggregateProfunctor = it "" $ q `queryShouldReturnSorted` [(1, 1200) :: (Int, Int64), (2, 300)]
   where q = O.aggregate (PP.p2 (O.groupBy, countsum)) table1Q
-        expected r = [(1, 1200) :: (Int, Int64), (2, 300)] == L.sort r
         countsum = P.dimap (\x -> (x,x))
                            (\(x, y) -> aggregateCoerceFIXME' x * y)
                            (PP.p2 (O.sum, O.count))
 
 testStringArrayAggregate :: Test
-testStringArrayAggregate = testG q expected
+testStringArrayAggregate = it "" $ q `queryShouldReturnSorted` [(map fst table6data, minimum (map snd table6data))]
   where q = O.aggregate (PP.p2 (O.arrayAgg, O.min)) table6Q
-        expected r = [(map fst table6data, minimum (map snd table6data))] == r
 
 testStringAggregate :: Test
-testStringAggregate = testG q expected
+testStringAggregate = it "" $ q `queryShouldReturnSorted` expected
   where q = O.aggregate (PP.p2 ((O.stringAgg . O.pgString) "_", O.groupBy)) table6Q
-        expected r = [(
+        expected = [(
           (foldl1 (\x y -> x ++ "_" ++ y) . map fst) table6data ,
-          head (map snd table6data))] == r
+          head (map snd table6data))]
 
 -- | Using aggregateOrdered applies the ordering to all aggregates.
 
 testStringArrayAggregateOrdered :: Test
-testStringArrayAggregateOrdered = testG q expected
+testStringArrayAggregateOrdered = it "" $ q `queryShouldReturnSorted` expected
   where q = O.aggregateOrdered (O.asc snd) (PP.p2 (O.arrayAgg, O.stringAgg . O.pgString $ ",")) table7Q
-        expected r = [( map fst sortedData
+        expected = [( map fst sortedData
                       , L.intercalate "," . map snd $ sortedData
                       )
-                     ] == r
+                     ]
         sortedData = L.sortBy (Ord.comparing snd) table7data
 
 -- | Using orderAggregate you can apply different orderings to
 -- different aggregates.
 
 testMultipleAggregateOrdered :: Test
-testMultipleAggregateOrdered = testG q expected
+testMultipleAggregateOrdered = it "" $ q `queryShouldReturnSorted` expected
   where q = O.aggregate ((,) <$> IA.orderAggregate (O.asc snd)
                                                    (P.lmap fst O.arrayAgg)
                              <*> IA.orderAggregate (O.desc snd)
                                                    (P.lmap snd (O.stringAgg . O.pgString $ ","))
                         ) table7Q
-        expected r = [( map fst . L.sortBy (Ord.comparing snd) $ table7data
+        expected = [( map fst . L.sortBy (Ord.comparing snd) $ table7data
                       , L.intercalate "," . map snd . L.sortBy (Ord.comparing (Ord.Down . snd)) $ table7data
                       )
-                     ] == r
+                     ]
 
 -- | Applying an order to an ordered aggregate overwrites the old
 -- order, just like with ordered queries.
 --
 testOverwriteAggregateOrdered :: Test
-testOverwriteAggregateOrdered = testG q expected
+testOverwriteAggregateOrdered = it "" $ q `queryShouldReturnSorted` expected
   where q = O.aggregate ( IA.orderAggregate (O.asc snd)
                         . IA.orderAggregate (O.desc snd)
                         $ PP.p2 (O.arrayAgg, O.max)
                         ) table7Q
-        expected r = [( map fst (L.sortBy (Ord.comparing snd) table7data)
+        expected = [( map fst (L.sortBy (Ord.comparing snd) table7data)
                       , maximum (map snd table7data)
                       )
-                     ] == r
+                     ]
 
 testCountRows0 :: Test
-testCountRows0 = testG q expected
+testCountRows0 = it "" $ q `queryShouldReturnSorted` [0 :: Int64]
   where q        = O.countRows (O.keepWhen (const (O.pgBool False)) <<< table7Q)
-        expected = (== [0 :: Int64])
 
 testCountRows3 :: Test
-testCountRows3 = testG q expected
+testCountRows3 = it "" $ q `queryShouldReturnSorted` [3 :: Int64]
   where q        = O.countRows table7Q
-        expected = (== [3 :: Int64])
 
-testOrderByG :: O.Order (Column O.PGInt4, Column O.PGInt4)
+queryShouldReturnSortBy :: O.Order (Column O.PGInt4, Column O.PGInt4)
                 -> ((Int, Int) -> (Int, Int) -> Ordering)
-                -> Test
-testOrderByG orderQ order = testG (O.orderBy orderQ table1Q)
-                                  (L.sortBy order table1data ==)
+                -> (PGS.Connection -> Expectation)
+queryShouldReturnSortBy orderQ order = testH (O.orderBy orderQ table1Q)
+                                  (L.sortBy order table1data `shouldBe`)
 
 testOrderBy :: Test
-testOrderBy = testOrderByG (O.desc snd)
+testOrderBy = it "" $ queryShouldReturnSortBy (O.desc snd)
                            (flip (Ord.comparing snd))
 
 testOrderBy2 :: Test
-testOrderBy2 = testOrderByG (O.desc fst <> O.asc snd)
+testOrderBy2 = it "" $ queryShouldReturnSortBy (O.desc fst <> O.asc snd)
                             (flip (Ord.comparing fst) <> Ord.comparing snd)
 
 testOrderBySame :: Test
-testOrderBySame = testOrderByG (O.desc fst <> O.asc fst)
+testOrderBySame = it "" $ queryShouldReturnSortBy (O.desc fst <> O.asc fst)
                                (flip (Ord.comparing fst) <> Ord.comparing fst)
 
-testLOG :: (Query (Column O.PGInt4, Column O.PGInt4) -> Query (Column O.PGInt4, Column O.PGInt4))
-           -> ([(Int, Int)] -> [(Int, Int)]) -> Test
-testLOG olQ ol = testG (olQ (orderQ table1Q))
-                       (ol (order table1data) ==)
+limitOrderShouldMatch :: (Query (Column O.PGInt4, Column O.PGInt4) -> Query (Column O.PGInt4, Column O.PGInt4))
+           -> ([(Int, Int)] -> [(Int, Int)]) -> (PGS.Connection -> Expectation)
+limitOrderShouldMatch olQ ol = testH (olQ (orderQ table1Q))
+                       (ol (order table1data) `shouldBe`)
   where orderQ = O.orderBy (O.desc snd)
         order = L.sortBy (flip (Ord.comparing snd))
 
 testLimit :: Test
-testLimit = testLOG (O.limit 2) (take 2)
+testLimit = it "" $ limitOrderShouldMatch (O.limit 2) (take 2)
 
 testOffset :: Test
-testOffset = testLOG (O.offset 2) (drop 2)
+testOffset = it "" $ limitOrderShouldMatch (O.offset 2) (drop 2)
 
 testLimitOffset :: Test
-testLimitOffset = testLOG (O.limit 2 . O.offset 2) (take 2 . drop 2)
+testLimitOffset = it "" $ limitOrderShouldMatch (O.limit 2 . O.offset 2) (take 2 . drop 2)
 
 testOffsetLimit :: Test
-testOffsetLimit = testLOG (O.offset 2 . O.limit 2) (drop 2 . take 2)
+testOffsetLimit = it "" $ limitOrderShouldMatch (O.offset 2 . O.limit 2) (drop 2 . take 2)
 
 testDistinctAndAggregate :: Test
-testDistinctAndAggregate = testG q expected
+testDistinctAndAggregate = it "" $ q `queryShouldReturnSorted` expectedResult
   where q = O.distinct table1Q
             &&& (Arr.second aggregateCoerceFIXME
                  <<< O.aggregate (PP.p2 (O.groupBy, O.sum)) table1Q)
-        expected r = L.sort r == L.sort expectedResult
         expectedResult = A.liftA2 (,) (L.nub table1data)
                                       [(1 :: Int, 400 :: Int64), (2, 300)]
 
@@ -553,31 +547,31 @@ one = Arr.arr (const (1 :: Column O.PGInt4))
 
 -- The point of the "double" tests is to ensure that we do not
 -- introduce name clashes in the operations which create new column names
-testDoubleG :: (Eq haskells, D.Default O.QueryRunner columns haskells) =>
+testDoubleH :: (Show haskells, Eq haskells, D.Default O.QueryRunner columns haskells) =>
                (QueryArr () (Column O.PGInt4) -> QueryArr () columns) -> [haskells]
-               -> Test
-testDoubleG q expected1 = testG (q one &&& q one) (== expected2)
+               -> (PGS.Connection -> Expectation)
+testDoubleH q expected1 = testH (q one &&& q one) (`shouldBe` expected2)
   where expected2 = A.liftA2 (,) expected1 expected1
 
 testDoubleDistinct :: Test
-testDoubleDistinct = testDoubleG O.distinct [1 :: Int]
+testDoubleDistinct = it "" $ testDoubleH O.distinct [1 :: Int]
 
 testDoubleAggregate :: Test
-testDoubleAggregate = testDoubleG (O.aggregate O.count) [1 :: Int64]
+testDoubleAggregate = it "" $ testDoubleH (O.aggregate O.count) [1 :: Int64]
 
 testDoubleLeftJoin :: Test
-testDoubleLeftJoin = testDoubleG lj [(1 :: Int, Just (1 :: Int))]
+testDoubleLeftJoin = it "" $ testDoubleH lj [(1 :: Int, Just (1 :: Int))]
   where lj :: Query (Column O.PGInt4)
           -> Query (Column O.PGInt4, Column (Nullable O.PGInt4))
         lj q = O.leftJoin q q (uncurry (.==))
 
 testDoubleValues :: Test
-testDoubleValues = testDoubleG v [1 :: Int]
+testDoubleValues = it "" $ testDoubleH v [1 :: Int]
   where v :: Query (Column O.PGInt4) -> Query (Column O.PGInt4)
         v _ = O.values [1]
 
 testDoubleUnionAll :: Test
-testDoubleUnionAll = testDoubleG u [1 :: Int, 1]
+testDoubleUnionAll = it "" $ testDoubleH u [1 :: Int, 1]
   where u q = q `O.unionAll` q
 
 aLeftJoin :: Query ((Column O.PGInt4, Column O.PGInt4),
@@ -585,7 +579,7 @@ aLeftJoin :: Query ((Column O.PGInt4, Column O.PGInt4),
 aLeftJoin = O.leftJoin table1Q table3Q (\(l, r) -> fst l .== fst r)
 
 testLeftJoin :: Test
-testLeftJoin = testG aLeftJoin (== expected)
+testLeftJoin = it "" $ testH aLeftJoin (`shouldBe` expected)
   where expected :: [((Int, Int), (Maybe Int, Maybe Int))]
         expected = [ ((1, 100), (Just 1, Just 50))
                    , ((1, 100), (Just 1, Just 50))
@@ -593,7 +587,7 @@ testLeftJoin = testG aLeftJoin (== expected)
                    , ((2, 300), (Nothing, Nothing)) ]
 
 testLeftJoinNullable :: Test
-testLeftJoinNullable = testG q (== expected)
+testLeftJoinNullable = it "" $ testH q (`shouldBe` expected)
   where q :: Query ((Column O.PGInt4, Column O.PGInt4),
                     ((Column (Nullable O.PGInt4), Column (Nullable O.PGInt4)),
                      (Column (Nullable O.PGInt4),
@@ -608,7 +602,7 @@ testLeftJoinNullable = testG q (== expected)
                    , ((1, 50), ((Just 1, Just 200), (Just 1, Just 50))) ]
 
 testLeftJoinF :: Test
-testLeftJoinF = testG q (== expected)
+testLeftJoinF = it "" $ testH q (`shouldBe` expected)
   where q = O.leftJoinF (,)
                         (\x -> (x, (-1, -2)))
                         (\l r -> fst l .== fst r)
@@ -622,12 +616,12 @@ testLeftJoinF = testG q (== expected)
                    , ((2, 300), (-1, -2)) ]
 
 testThreeWayProduct :: Test
-testThreeWayProduct = testG q (== expected)
+testThreeWayProduct = it "" $ testH q (`shouldBe` expected)
   where q = A.liftA3 (,,) table1Q table2Q table3Q
         expected = A.liftA3 (,,) table1data table2data table3data
 
 testValues :: Test
-testValues = testG (O.values values) (values' ==)
+testValues = it "" $ testH (O.values values) (values' `shouldBe`)
   where values :: [(Column O.PGInt4, Column O.PGInt4)]
         values = [ (1, 10)
                  , (2, 100) ]
@@ -647,40 +641,36 @@ testValuesDouble = testG (O.values values) (values' ==)
 -}
 
 testValuesEmpty :: Test
-testValuesEmpty = testG (O.values values) (values' ==)
+testValuesEmpty = it "" $ testH (O.values values) (values' `shouldBe`)
   where values :: [Column O.PGInt4]
         values = []
         values' :: [Int]
         values' = []
 
 testUnionAll :: Test
-testUnionAll = testG (table1Q `O.unionAll` table2Q)
-                     (\r -> L.sort (table1data ++ table2data) == L.sort r)
+testUnionAll = it "" $  (table1Q `O.unionAll` table2Q) `queryShouldReturnSorted` (table1data ++ table2data)
 
 testTableFunctor :: Test
-testTableFunctor = testG (O.queryTable table1F) (result ==)
+testTableFunctor = it "" $ testH (O.queryTable table1F) (result `shouldBe`)
   where result = fmap (\(col1, col2) -> (col1 + col2, col1 - col2)) table1data
 
 -- TODO: This is getting too complicated
 testUpdate :: Test
-testUpdate conn = do
+testUpdate = it "" $ \conn -> do
   _ <- O.runUpdate conn table4 update cond
-  result <- runQueryTable4
+  result <- runQueryTable4 conn
+  result `shouldBe` expected
 
-  if result /= expected
-    then return False
-    else do
-    _ <- O.runDelete conn table4 condD
-    resultD <- runQueryTable4
+  _ <- O.runDelete conn table4 condD
+  resultD <- runQueryTable4 conn
+  resultD `shouldBe` expectedD
 
-    if resultD /= expectedD
-      then return False
-      else do
-      returned <- O.runInsertManyReturning conn table4 insertT returning
-      _ <- O.runInsertMany conn table4 insertTMany
-      resultI <- runQueryTable4
+  returned <- O.runInsertManyReturning conn table4 insertT returning
+  _ <- O.runInsertMany conn table4 insertTMany
+  resultI <- runQueryTable4 conn
 
-      return ((resultI == expectedI) && (returned == expectedR))
+  resultI `shouldBe` expectedI
+  returned `shouldBe` expectedR
 
   where update (x, y) = (x + y, x - y)
         cond (_, y) = y .> 15
@@ -690,7 +680,7 @@ testUpdate conn = do
                    , (22, -18)]
         expectedD :: [(Int, Int)]
         expectedD = [(1, 10)]
-        runQueryTable4 = O.runQuery conn (O.queryTable table4)
+        runQueryTable4 conn = O.runQuery conn (O.queryTable table4)
 
         insertT :: [(Column O.PGInt4, Column O.PGInt4)]
         insertT = [(1, 2), (3, 5)]
@@ -705,14 +695,14 @@ testUpdate conn = do
         expectedR = [-1, -2]
 
 testKeywordColNames :: Test
-testKeywordColNames conn = do
+testKeywordColNames = it "" $ \conn -> do
   let q :: IO [(Int, Int)]
       q = O.runQuery conn (O.queryTable tableKeywordColNames)
   _ <- q
-  return True
+  True `shouldBe` True
 
 testInsertSerial :: Test
-testInsertSerial conn = do
+testInsertSerial = it "" $ \conn -> do
   _ <- O.runInsert conn table5 (Just 10, Just 20)
   _ <- O.runInsert conn table5 (Just 30, Nothing)
   _ <- O.runInsert conn table5 (Nothing, Nothing)
@@ -720,7 +710,7 @@ testInsertSerial conn = do
 
   resultI <- O.runQuery conn (O.queryTable table5)
 
-  return (resultI == expected)
+  resultI `shouldBe` expected
 
   where expected :: [(Int, Int)]
         expected = [ (10, 20)
@@ -729,41 +719,42 @@ testInsertSerial conn = do
                    , (2, 40) ]
 
 testInQuery :: Test
-testInQuery conn = do
-  let q (x, e) = testG (O.inQuery x (O.queryTable table1)) (== [e]) conn
+testInQuery = it "" $ \conn -> do
+  let q (x, e) = testH (O.inQuery x (O.queryTable table1)) (`shouldBe` [e]) conn
 
-  r <- mapM (q . (\x ->      (x,        True)))  table1dataG
-  s <- mapM (q . (\(x, y) -> ((x, y+1), False))) table1dataG
+  mapM_ (q . (\x ->      (x,        True)))  table1dataG
+  mapM_ (q . (\(x, y) -> ((x, y+1), False))) table1dataG
 
-  return (and r && and s)
+  -- and r && and s `shouldBe` True
 
 testAtTimeZone :: Test
-testAtTimeZone = testG (A.pure (O.timestamptzAtTimeZone t (O.pgString "CET"))) (== [t'])
+testAtTimeZone = it "" $ testH (A.pure (O.timestamptzAtTimeZone t (O.pgString "CET"))) (`shouldBe` [t'])
   where t = O.pgUTCTime (Time.UTCTime d (Time.secondsToDiffTime 3600))
         t' = Time.LocalTime d (Time.TimeOfDay 2 0 0)
         d = Time.fromGregorian 2015 1 1
 
 testArrayLiterals :: Test
-testArrayLiterals = testG (A.pure $ O.pgArray O.pgInt4 vals) (== [vals])
+testArrayLiterals = it "" $ testH (A.pure $ O.pgArray O.pgInt4 vals) (`shouldBe` [vals])
   where vals = [1,2,3]
 
 -- This test fails without the explicit cast in pgArray since postgres
 -- can't determine the type of the array.
 
 testEmptyArray :: Test
-testEmptyArray = testG (A.pure $ O.pgArray O.pgInt4 []) (== [[] :: [Int]])
+testEmptyArray = it "" $ testH (A.pure $ O.pgArray O.pgInt4 []) (`shouldBe` [[] :: [Int]])
 
 -- This test fails without the explicit cast in pgArray since postgres
 -- defaults the numbers to 'integer' but postgresql-simple expects 'float8'.
 
 testFloatArray :: Test
-testFloatArray = testG (A.pure $ O.pgArray O.pgDouble doubles) (== [doubles])
+testFloatArray = it "" $ testH (A.pure $ O.pgArray O.pgDouble doubles) (`shouldBe` [doubles])
   where
     doubles = [1 :: Double, 2]
 
+type JsonTest a = SpecWith (Query (Column a) -> PGS.Connection -> Expectation)
 -- Test opaleye's equivalent of c1->'c'
 testJsonGetFieldValue :: (O.PGIsJson a, O.QueryRunnerColumnDefault a Json.Value) => Query (Column a) -> Test
-testJsonGetFieldValue dataQuery = testG q (== expected)
+testJsonGetFieldValue dataQuery = it "" $ testH q (`shouldBe` expected)
   where q = dataQuery >>> proc c1 -> do
             Arr.returnA -< O.toNullable c1 O..-> O.pgStrictText "c"
         expected :: [Maybe Json.Value]
@@ -771,7 +762,7 @@ testJsonGetFieldValue dataQuery = testG q (== expected)
 
 -- Test opaleye's equivalent of c1->>'c'
 testJsonGetFieldText :: (O.PGIsJson a) => Query (Column a) -> Test
-testJsonGetFieldText dataQuery = testG q (== expected)
+testJsonGetFieldText dataQuery = it "" $ testH q (`shouldBe` expected)
   where q = dataQuery >>> proc c1 -> do
             Arr.returnA -< O.toNullable c1 O..->> O.pgStrictText "c"
         expected :: [Maybe T.Text]
@@ -779,7 +770,7 @@ testJsonGetFieldText dataQuery = testG q (== expected)
 
 -- Test opaleye's equivalent of c1->'a'->2
 testJsonGetArrayValue :: (O.PGIsJson a, O.QueryRunnerColumnDefault a Json.Value) => Query (Column a) -> Test
-testJsonGetArrayValue dataQuery = testG q (== expected)
+testJsonGetArrayValue dataQuery = it "" $ testH q (`shouldBe` expected)
   where q = dataQuery >>> proc c1 -> do
             Arr.returnA -< O.toNullable c1 O..-> O.pgStrictText "a" O..-> O.pgInt4 2
         expected :: [Maybe Json.Value]
@@ -787,7 +778,7 @@ testJsonGetArrayValue dataQuery = testG q (== expected)
 
 -- Test opaleye's equivalent of c1->'a'->>2
 testJsonGetArrayText :: (O.PGIsJson a) => Query (Column a) -> Test
-testJsonGetArrayText dataQuery = testG q (== expected)
+testJsonGetArrayText dataQuery = it "" $ testH q (`shouldBe` expected)
   where q = dataQuery >>> proc c1 -> do
             Arr.returnA -< O.toNullable c1 O..-> O.pgStrictText "a" O..->> O.pgInt4 2
         expected :: [Maybe T.Text]
@@ -796,15 +787,15 @@ testJsonGetArrayText dataQuery = testG q (== expected)
 -- Test opaleye's equivalent of c1->>'missing'
 -- Note that the missing field does not exist.
 testJsonGetMissingField :: (O.PGIsJson a) => Query (Column a) -> Test
-testJsonGetMissingField dataQuery = testG q (== expected)
+testJsonGetMissingField dataQuery = it "" $ testH q (`shouldBe` expected)
   where q = dataQuery >>> proc c1 -> do
             Arr.returnA -< O.toNullable c1 O..->> O.pgStrictText "missing"
         expected :: [Maybe T.Text]
         expected = [Nothing]
 
 -- Test opaleye's equivalent of c1#>'{b,x}'
-testJsonGetPathValue :: (O.PGIsJson a, O.QueryRunnerColumnDefault a Json.Value) => Query (Column a) -> Test
-testJsonGetPathValue dataQuery = testG q (== expected)
+testJsonGetPathValue :: (O.PGIsJson a, O.QueryRunnerColumnDefault a Json.Value) => (Query (Column a)) -> Test
+testJsonGetPathValue dataQuery = it "" $ testH q (`shouldBe` expected)
   where q = dataQuery >>> proc c1 -> do
               Arr.returnA -< O.toNullable c1 O..#> O.pgArray O.pgStrictText ["b", "x"]
         expected :: [Maybe Json.Value]
@@ -812,7 +803,7 @@ testJsonGetPathValue dataQuery = testG q (== expected)
 
 -- Test opaleye's equivalent of c1#>>'{b,x}'
 testJsonGetPathText :: (O.PGIsJson a) => Query (Column a) -> Test
-testJsonGetPathText dataQuery = testG q (== expected)
+testJsonGetPathText dataQuery = it "" $ testH q (`shouldBe` expected)
   where q = dataQuery >>> proc c1 -> do
               Arr.returnA -< O.toNullable c1 O..#>> O.pgArray O.pgStrictText ["b", "x"]
         expected :: [Maybe T.Text]
@@ -820,99 +811,76 @@ testJsonGetPathText dataQuery = testG q (== expected)
 
 -- Test opaleye's equivalent of c1 @> '{"c":21}'::jsonb
 testJsonbRightInLeft :: Test
-testJsonbRightInLeft = testG q (== [True])
+testJsonbRightInLeft = it "" $ testH q (`shouldBe` [True])
   where q = table9Q >>> proc c1 -> do
               Arr.returnA -< c1 O..@> O.pgJSONB "{\"c\":21}"
 
 -- Test opaleye's equivalent of '{"c":21}'::jsonb <@ c1
 testJsonbLeftInRight :: Test
-testJsonbLeftInRight = testG q (== [True])
+testJsonbLeftInRight = it "" $ testH q (`shouldBe` [True])
   where q = table9Q >>> proc c1 -> do
               Arr.returnA -< O.pgJSONB "{\"c\":21}" O..<@ c1
 
 -- Test opaleye's equivalent of c1 ? 'b'
 testJsonbContains :: Test
-testJsonbContains = testG q (== [True])
+testJsonbContains = it "" $ testH q (`shouldBe` [True])
   where q = table9Q >>> proc c1 -> do
               Arr.returnA -< c1 O..? O.pgStrictText "c"
 
 -- Test opaleye's equivalent of c1 ? 'missing'
 -- Note that the missing field does not exist.
 testJsonbContainsMissing :: Test
-testJsonbContainsMissing = testG q (== [False])
+testJsonbContainsMissing = it "" $ testH q (`shouldBe` [False])
   where q = table9Q >>> proc c1 -> do
               Arr.returnA -< c1 O..? O.pgStrictText "missing"
 
 -- Test opaleye's equivalent of c1 ?| array['b', 'missing']
 testJsonbContainsAny :: Test
-testJsonbContainsAny = testG q (== [True])
+testJsonbContainsAny = it "" $ testH q (`shouldBe` [True])
   where q = table9Q >>> proc c1 -> do
               Arr.returnA -< c1 O..?| O.pgArray O.pgStrictText ["b", "missing"]
 
 -- Test opaleye's equivalent of c1 ?& array['a', 'b', 'c']
 testJsonbContainsAll :: Test
-testJsonbContainsAll = testG q (== [True])
+testJsonbContainsAll = it "" $ testH q (`shouldBe` [True])
   where q = table9Q >>> proc c1 -> do
               Arr.returnA -< c1 O..?& O.pgArray O.pgStrictText ["a", "b", "c"]
 
 testRangeOverlap :: Test
-testRangeOverlap = testG q (== [True])
+testRangeOverlap = it "generates overlap" $ testH q (`shouldBe` [True])
   where range :: Int -> Int -> Column (O.PGRange O.PGInt4)
         range a b = O.pgRange O.pgInt4 (R.Inclusive a) (R.Inclusive b)
         q = A.pure $ (range 3 7) `O.overlap` (range 4 12)
 
 testRangeLeftOf :: Test
-testRangeLeftOf = testG q (== [True])
+testRangeLeftOf = it "generates 'left of'" $ testH q (`shouldBe` [True])
   where range :: Int -> Int -> Column (O.PGRange O.PGInt4)
         range a b = O.pgRange O.pgInt4 (R.Inclusive a) (R.Inclusive b)
         q = A.pure $ (range 1 10) O..<< (range 100 110)
 
 testRangeRightOf :: Test
-testRangeRightOf = testG q (== [True])
+testRangeRightOf = it "generates 'right of'" $ testH q (`shouldBe` [True])
   where range :: Int -> Int -> Column (O.PGRange O.PGInt4)
         range a b = O.pgRange O.pgInt4 (R.Inclusive a) (R.Inclusive b)
         q = A.pure $ (range 50 60) O..>> (range 20 30)
 
 testRangeRightExtension :: Test
-testRangeRightExtension = testG q (== [True])
+testRangeRightExtension = it "generates right extension" $ testH q (`shouldBe` [True])
   where range :: Int -> Int -> Column (O.PGRange O.PGInt4)
         range a b = O.pgRange O.pgInt4 (R.Inclusive a) (R.Inclusive b)
         q = A.pure $ (range 1 20) O..&< (range 18 20)
 
 testRangeLeftExtension :: Test
-testRangeLeftExtension = testG q (== [True])
+testRangeLeftExtension = it "generates left extension" $ testH q (`shouldBe` [True])
   where range :: Int -> Int -> Column (O.PGRange O.PGInt4)
         range a b = O.pgRange O.pgInt4 (R.Inclusive a) (R.Inclusive b)
         q = A.pure $ (range 7 20) O..&> (range 5 10)
 
 testRangeAdjacency :: Test
-testRangeAdjacency = testG q (== [True])
+testRangeAdjacency = it "generates adjacency" $ testH q (`shouldBe` [True])
   where range :: Int -> Int -> Column (O.PGRange O.PGInt4)
         range a b = O.pgRange O.pgInt4 (R.Inclusive a) (R.Exclusive b)
         q = A.pure $ (range 1 2) O..-|- (range 2 3)
-
-allTests :: [Test]
-allTests = [testSelect, testProduct, testRestrict, testNum, testDiv, testCase,
-            testDistinct, testAggregate, testAggregate0, testAggregateFunction,
-            testAggregateProfunctor, testStringArrayAggregate, testStringAggregate,
-            testOrderBy, testOrderBy2, testOrderBySame, testLimit, testOffset,
-            testLimitOffset, testOffsetLimit, testDistinctAndAggregate, testIn,
-            testDoubleDistinct, testDoubleAggregate, testDoubleLeftJoin,
-            testDoubleValues, testDoubleUnionAll,
-            testLeftJoin, testLeftJoinNullable, testThreeWayProduct, testValues,
-            testLeftJoinF,
-            testValuesEmpty, testUnionAll, testTableFunctor, testUpdate,
-            testKeywordColNames, testInsertSerial, testInQuery, testAtTimeZone,
-            testStringArrayAggregateOrdered, testMultipleAggregateOrdered,
-            testOverwriteAggregateOrdered, testCountRows0, testCountRows3,
-            testArrayLiterals, testEmptyArray, testFloatArray, testCaseEmpty,
-            testJsonGetFieldValue   table8Q, testJsonGetFieldText  table8Q,
-            testJsonGetMissingField table8Q, testJsonGetArrayValue table8Q,
-            testJsonGetArrayText    table8Q, testJsonGetPathValue  table8Q,
-            testJsonGetPathText     table8Q,
-            testRangeOverlap, testRangeLeftOf, testRangeRightOf,
-            testRangeRightExtension, testRangeLeftExtension, testRangeAdjacency
-            ]
 
 -- Note: these tests are left out of allTests until Travis supports
 -- Postgresql >= 9.4
@@ -968,12 +936,80 @@ main = do
   -- Need to run quickcheck after table data has been inserted
   QuickCheck.run conn
 
-  results <- mapM ($ conn) allTests
-
-  print results
-
-  let passed = and results
-
-  putStrLn (if passed then "All passed" else "Failure")
-  Exit.exitWith (if passed then Exit.ExitSuccess
-                           else Exit.ExitFailure 1)
+  hspec $ do
+    before (return conn) $ do
+      describe "core dsl?" $ do
+        testSelect
+        testProduct
+        testRestrict
+        testIn
+        testNum
+        testDiv
+      describe "cases" $ do
+        testCase
+        testCaseEmpty
+      describe "aggregate" $ do
+        testAggregate
+        testAggregate0
+        testAggregateFunction
+        testAggregateProfunctor
+        testStringArrayAggregate
+        testStringAggregate
+        testOverwriteAggregateOrdered
+        testMultipleAggregateOrdered
+        testStringArrayAggregateOrdered
+        testDistinctAndAggregate
+        testDoubleAggregate
+      describe "distinct" $ do
+        testDistinct
+      describe "order" $ do
+        testOrderBy
+        testOrderBy2
+        testOrderBySame
+      describe "count" $ do
+        testCountRows0
+        testCountRows3
+      describe "limit" $ do
+        testLimit
+        testOffset
+        testLimitOffset
+        testOffsetLimit
+      describe "double" $ do
+        testDoubleDistinct
+        testDoubleLeftJoin
+        testDoubleValues
+        testDoubleUnionAll
+      describe "arrays" $ do
+        testArrayLiterals
+        testEmptyArray
+        testFloatArray
+      describe "joins" $ do
+        testLeftJoin
+        testLeftJoinNullable
+        testThreeWayProduct
+        testLeftJoinF
+      describe "json" $ do
+        testJsonGetFieldValue   table8Q
+        testJsonGetFieldText    table8Q
+        testJsonGetMissingField table8Q
+        testJsonGetArrayValue   table8Q
+        testJsonGetArrayText    table8Q
+        testJsonGetPathValue    table8Q
+        testJsonGetPathText     table8Q
+      describe "uncat" $ do
+        testKeywordColNames
+        testInsertSerial
+        testInQuery
+        testAtTimeZone
+        testUnionAll
+        testTableFunctor
+        testValues
+        testValuesEmpty
+        testUpdate
+      describe "range" $ do
+        testRangeOverlap
+        testRangeLeftOf
+        testRangeRightOf
+        testRangeRightExtension
+        testRangeLeftExtension
+        testRangeAdjacency

--- a/opaleye.cabal
+++ b/opaleye.cabal
@@ -112,6 +112,8 @@ test-suite test
     semigroups,
     text >= 0.11 && < 1.3,
     time,
+    hspec,
+    hspec-discover,
     opaleye
   ghc-options: -Wall
 


### PR DESCRIPTION
I've refactored the test suite to use HSpec.

This is still very much WIP, however I figured I'd start gathering opinions on the changes now. I am pleasantly surprised both by how easy it was to refactor and how it has enabled some miscellaneous cleanups!

TODO:

- [x] Re-enable Quickcheck
- [x] fix configuration

A followup PR will split `Test.hs` into submodules containing relevant suites (ie ranges, json, arrays, etc) and then we can leverage `hspec-discover` to build the test listing automatically. 