### PR TITLE
Looks like we don't actually need the Unpackspec component of QueryRunnerColumnDefault

### DIFF
--- a/src/Opaleye/Internal/RunQuery.hs
+++ b/src/Opaleye/Internal/RunQuery.hs
@@ -68,10 +68,10 @@ import           Data.Typeable (Typeable)
 -- FieldParser, so we have to have some type that we know contains
 -- just a FieldParser.
 data QueryRunnerColumn pgType haskellType =
-  QueryRunnerColumn (U.Unpackspec (Column pgType) ()) (FieldParser haskellType)
+  QueryRunnerColumn (FieldParser haskellType)
 
 instance Functor (QueryRunnerColumn u) where
-  fmap f ~(QueryRunnerColumn u fp) = QueryRunnerColumn u ((fmap . fmap . fmap) f fp)
+  fmap f ~(QueryRunnerColumn fp) = QueryRunnerColumn ((fmap . fmap . fmap) f fp)
 
 -- | A 'QueryRunner' specifies how to convert Postgres values (@columns@)
 --   into Haskell values (@haskells@).  Most likely you will never need
@@ -93,17 +93,17 @@ fieldQueryRunnerColumn :: FromField haskell => QueryRunnerColumn pgType haskell
 fieldQueryRunnerColumn = fieldParserQueryRunnerColumn fromField
 
 fieldParserQueryRunnerColumn :: FieldParser haskell -> QueryRunnerColumn pgType haskell
-fieldParserQueryRunnerColumn = QueryRunnerColumn (P.rmap (const ()) U.unpackspecColumn)
+fieldParserQueryRunnerColumn = QueryRunnerColumn
 
 queryRunner :: QueryRunnerColumn a b -> QueryRunner (Column a) b
-queryRunner qrc = QueryRunner u (const (fieldWith fp)) (const True)
-    where QueryRunnerColumn u fp = qrc
+queryRunner qrc = QueryRunner (P.rmap (const ()) U.unpackspecColumn) (const (fieldWith fp)) (const True)
+    where QueryRunnerColumn fp = qrc
 
 queryRunnerColumnNullable :: QueryRunnerColumn a b
                           -> QueryRunnerColumn (Nullable a) (Maybe b)
 queryRunnerColumnNullable qr =
-  QueryRunnerColumn (P.lmap C.unsafeCoerceColumn u) (fromField' fp)
-  where QueryRunnerColumn u fp = qr
+  QueryRunnerColumn (fromField' fp)
+  where QueryRunnerColumn fp = qr
         fromField' :: FieldParser a -> FieldParser (Maybe a)
         fromField' _ _ Nothing = pure Nothing
         fromField' fp' f bs = fmap Just (fp' f bs)
@@ -217,8 +217,10 @@ arrayColumn = C.unsafeCoerceColumn
 
 instance (Typeable b, QueryRunnerColumnDefault a b) =>
          QueryRunnerColumnDefault (T.PGArray a) [b] where
-  queryRunnerColumnDefault = QueryRunnerColumn (P.lmap arrayColumn c) ((fmap . fmap . fmap) fromPGArray (pgArrayFieldParser f))
-    where QueryRunnerColumn c f = queryRunnerColumnDefault
+  queryRunnerColumnDefault = foo queryRunnerColumnDefault
+    where foo :: Typeable b => QueryRunnerColumn a b -> QueryRunnerColumn (T.PGArray a) [b]
+          foo x = QueryRunnerColumn ((fmap . fmap . fmap) fromPGArray (pgArrayFieldParser f))
+            where QueryRunnerColumn f = x
 
 -- }
 

--- a/src/Opaleye/RunQuery.hs
+++ b/src/Opaleye/RunQuery.hs
@@ -14,13 +14,13 @@ import qualified Database.PostgreSQL.Simple.FromRow as FR
 import qualified Data.String as String
 
 import           Opaleye.Column (Column)
+import           Opaleye.Internal.Helpers ((.:))
 import qualified Opaleye.Sql as S
 import           Opaleye.QueryArr (Query)
 import           Opaleye.Internal.RunQuery (QueryRunner(QueryRunner))
 import qualified Opaleye.Internal.RunQuery as IRQ
 import qualified Opaleye.Internal.QueryArr as Q
 
-import qualified Data.Profunctor as P
 import qualified Data.Profunctor.Product.Default as D
 
 -- * Running 'Query's
@@ -82,10 +82,8 @@ runQueryFold = runQueryFoldExplicit D.def
 -- @
 queryRunnerColumn :: (Column a' -> Column a) -> (b -> b')
                   -> IRQ.QueryRunnerColumn a b -> IRQ.QueryRunnerColumn a' b'
-queryRunnerColumn colF haskellF qrc = IRQ.QueryRunnerColumn (P.lmap colF u)
-                                                            (fmapFP haskellF fp)
-  where IRQ.QueryRunnerColumn u fp = qrc
-        fmapFP = fmap . fmap . fmap
+queryRunnerColumn _ = changePhantom .: fmap
+  where changePhantom (IRQ.QueryRunnerColumn fp) = IRQ.QueryRunnerColumn fp
 
 -- * Explicit versions
 


### PR DESCRIPTION
Perhaps we should remove this?