### PR TITLE
Clean up compiler warnings

### DIFF
--- a/Doc/Tutorial/TutorialBasic.lhs
+++ b/Doc/Tutorial/TutorialBasic.lhs
@@ -22,7 +22,7 @@
 > import           Data.Profunctor.Product.TH (makeAdaptorAndInstance)
 > import           Data.Time.Calendar (Day)
 >
-> import           Control.Arrow (returnA, (<<<))
+> import           Control.Arrow (returnA)
 >
 > import qualified Database.PostgreSQL.Simple as PGS
 

--- a/Doc/Tutorial/TutorialBasicMonomorphic.lhs
+++ b/Doc/Tutorial/TutorialBasicMonomorphic.lhs
@@ -17,7 +17,7 @@
 >
 > import qualified Opaleye                 as O
 >
-> import           Control.Applicative     ((<$>), (<*>), Applicative)
+> import           Control.Applicative     ((<$>), (<*>))
 >
 > import qualified Data.Profunctor         as P
 > import           Data.Profunctor.Product (p3)

--- a/Doc/Tutorial/TutorialManipulation.lhs
+++ b/Doc/Tutorial/TutorialManipulation.lhs
@@ -9,7 +9,7 @@
 >                           PGInt4, PGFloat8)
 >
 > import           Data.Profunctor.Product (p4)
-> import           Data.Profunctor.Product.Default (Default, def)
+> import           Data.Profunctor.Product.Default (def)
 > import qualified Opaleye.Internal.Unpackspec as U
 > import qualified Opaleye.PGTypes as P
 > import qualified Opaleye.Constant as C

--- a/src/Opaleye/Aggregate.hs
+++ b/src/Opaleye/Aggregate.hs
@@ -1,3 +1,4 @@
+{-# OPTIONS_GHC -fno-warn-duplicate-exports #-}
 -- | Perform aggregation on 'Query's.  To aggregate a 'Query' you
 -- should construct an 'Aggregator' encoding how you want the
 -- aggregation to proceed, then call 'aggregate' on it.  The
@@ -88,7 +89,7 @@ aggregateOrdered o agg = aggregate (orderAggregate o agg)
 -- | Aggregate only distinct values
 distinctAggregator :: Aggregator a b -> Aggregator a b
 distinctAggregator (A.Aggregator (PM.PackMap pm)) =
-  A.Aggregator (PM.PackMap (\f c -> pm (f . P.first' (fmap (\(a,b,c) -> (a,b,HPQ.AggrDistinct)))) c))
+  A.Aggregator (PM.PackMap (\f c -> pm (f . P.first' (fmap (\(a,b,_) -> (a,b,HPQ.AggrDistinct)))) c))
 
 -- | Group the aggregation by equality on the input to 'groupBy'.
 groupBy :: Aggregator (C.Column a) (C.Column a)

--- a/src/Opaleye/Column.hs
+++ b/src/Opaleye/Column.hs
@@ -1,3 +1,4 @@
+{-# OPTIONS_GHC -fno-warn-duplicate-exports #-}
 -- | Functions for working directly with 'Column's.
 --
 -- Please note that numeric 'Column' types are instances of 'Num', so

--- a/src/Opaleye/Internal/Aggregate.hs
+++ b/src/Opaleye/Internal/Aggregate.hs
@@ -74,7 +74,7 @@ makeAggr = makeAggr' . Just
 
 orderAggregate :: O.Order a -> Aggregator a b -> Aggregator a b
 orderAggregate o (Aggregator (PM.PackMap pm)) =
-  Aggregator (PM.PackMap (\f c -> pm (f . P.first' (fmap ((\f (a,b,c) -> (a,f b,c)) (const $ O.orderExprs c o)))) c))
+  Aggregator (PM.PackMap (\f c -> pm (f . P.first' (fmap ((\f' (a,b,c') -> (a,f' b,c')) (const $ O.orderExprs c o)))) c))
 
 runAggregator :: Applicative f => Aggregator a b
               -> ((Maybe (HPQ.AggrOp, [HPQ.OrderExpr], HPQ.AggrDistinct), HPQ.PrimExpr) -> f HPQ.PrimExpr)

--- a/src/Opaleye/Internal/HaskellDB/Sql/Default.hs
+++ b/src/Opaleye/Internal/HaskellDB/Sql/Default.hs
@@ -125,8 +125,9 @@ defaultSqlExpr gen expr =
       AggrExpr distinct op e ord -> let op' = showAggrOp op
                                         e' = sqlExpr gen e
                                         ord' = toSqlOrder gen <$> ord
-                                        distinct' | distinct == AggrDistinct = SqlDistinct
-                                                  | distinct == AggrAll = SqlNotDistinct
+                                        distinct' = case distinct of
+                                                      AggrDistinct -> SqlDistinct
+                                                      AggrAll      -> SqlNotDistinct
                                         moreAggrFunParams = case op of
                                           AggrStringAggr primE -> [sqlExpr gen primE]
                                           _ -> []

--- a/src/Opaleye/Internal/RunQuery.hs
+++ b/src/Opaleye/Internal/RunQuery.hs
@@ -39,16 +39,9 @@ import           GHC.Int (Int32, Int64)
 
 import           Control.Applicative ((<$>))
 import           Database.PostgreSQL.Simple.FromField
-  (Field, typoid, typeOid, typelem, TypeInfo,
-   ResultError(UnexpectedNull, ConversionFailed, Incompatible),
-   typdelim, typeInfo, returnError, Conversion)
-import           Database.PostgreSQL.Simple.Types (PGArray(PGArray))
-import           Data.Attoparsec.ByteString.Char8 (Parser, parseOnly)
+  (ResultError(UnexpectedNull, Incompatible), typeInfo, returnError)
 import qualified Database.PostgreSQL.Simple.TypeInfo as TI
-import qualified Database.PostgreSQL.Simple.Arrays as Arrays
-import           Database.PostgreSQL.Simple.Arrays (array, fmt)
 import qualified Database.PostgreSQL.Simple.Range as PGSR
-import           Data.String (fromString)
 import           Data.Typeable (Typeable)
 
 -- }


### PR DESCRIPTION
Eliminate all current compiler warnings.

I simply suppressed the duplicate export warnings in `src/Opaleye/Aggregate` and `src/Opaleye/Column` as it appears that you intentionally want to export duplicates in order to get the Haddocks to look how you wish.