### PR TITLE
Enabled cache on Travis to speed up build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,11 @@ env:
 script:
 - curl -sL https://raw.github.com/tomjaguarpaw/neil/master/travis.sh | sh
 
+cache:
+  directories:
+  - $HOME/.ghc
+  - $HOME/.cabal
+
 before_script:
 - export POSTGRES_CONNSTRING="user='postgres' dbname='opaleye_test'"
 - psql -c 'create database opaleye_test;' -U postgres


### PR DESCRIPTION
I've noticed that Travis build takes about 1 hour now.
This should speed it up.