### PR TITLE
Fix time range queries

### DIFF
--- a/Test/Test.hs
+++ b/Test/Test.hs
@@ -785,7 +785,7 @@ testJsonGetFieldText dataQuery = it "" $ testH q (`shouldBe` expected)
             Arr.returnA -< O.toNullable c1 O..->> O.pgStrictText "c"
         expected :: [Maybe T.Text]
         expected = [Just "21"]
-      
+
 -- Special Test for Github Issue #350 : https://github.com/tomjaguarpaw/haskell-opaleye/issues/350
 testRestrictWithJsonOp :: (O.PGIsJson a) => Query (Column a) -> Test
 testRestrictWithJsonOp dataQuery = it "restricts the rows returned by checking equality with a value extracted using JSON operator" $ testH query (`shouldBe` table8data)
@@ -877,6 +877,19 @@ testRangeOverlap = it "generates overlap" $ testH q (`shouldBe` [True])
   where range :: Int -> Int -> Column (O.PGRange O.PGInt4)
         range a b = O.pgRange O.pgInt4 (R.Inclusive a) (R.Inclusive b)
         q = A.pure $ (range 3 7) `O.overlap` (range 4 12)
+
+testRangeDateOverlap :: Test
+testRangeDateOverlap = it "generates time overlap" $ \conn -> do
+    now <- Time.getCurrentTime
+    let later     = Time.addUTCTime 10 now
+        range1     = O.pgRange O.pgUTCTime (R.Inclusive now) (R.Inclusive later)
+        range2     = O.pgRange O.pgUTCTime R.NegInfinity R.PosInfinity
+        rangeNow   = O.pgRange O.pgUTCTime (R.Inclusive now) (R.Inclusive now)
+        qOverlap r = A.pure $ r `O.overlap` rangeNow
+    traverse putStrLn . O.showSqlForPostgres $ proc () -> Arr.returnA -< range1
+    traverse putStrLn . O.showSqlForPostgres $ proc () -> Arr.returnA -< range2
+    testH (qOverlap range1) (`shouldBe` [True]) conn
+    testH (qOverlap range2) (`shouldBe` [True]) conn
 
 testRangeLeftOf :: Test
 testRangeLeftOf = it "generates 'left of'" $ testH q (`shouldBe` [True])
@@ -1036,6 +1049,7 @@ main = do
         testUpdate
       describe "range" $ do
         testRangeOverlap
+        testRangeDateOverlap
         testRangeLeftOf
         testRangeRightOf
         testRangeRightExtension

--- a/Test/Test.hs
+++ b/Test/Test.hs
@@ -882,7 +882,7 @@ testRangeDateOverlap :: Test
 testRangeDateOverlap = it "generates time overlap" $ \conn -> do
     now <- Time.getCurrentTime
     let later     = Time.addUTCTime 10 now
-        range1     = O.pgRange O.pgUTCTime (R.Inclusive now) (R.Inclusive later)
+        range1     = O.pgRange O.pgUTCTime (R.Inclusive now) (R.Exclusive later)
         range2     = O.pgRange O.pgUTCTime R.NegInfinity R.PosInfinity
         rangeNow   = O.pgRange O.pgUTCTime (R.Inclusive now) (R.Inclusive now)
         qOverlap r = A.pure $ r `O.overlap` rangeNow

--- a/Test/Test.hs
+++ b/Test/Test.hs
@@ -886,8 +886,6 @@ testRangeDateOverlap = it "generates time overlap" $ \conn -> do
         range2     = O.pgRange O.pgUTCTime R.NegInfinity R.PosInfinity
         rangeNow   = O.pgRange O.pgUTCTime (R.Inclusive now) (R.Inclusive now)
         qOverlap r = A.pure $ r `O.overlap` rangeNow
-    traverse putStrLn . O.showSqlForPostgres $ proc () -> Arr.returnA -< range1
-    traverse putStrLn . O.showSqlForPostgres $ proc () -> Arr.returnA -< range2
     testH (qOverlap range1) (`shouldBe` [True]) conn
     testH (qOverlap range2) (`shouldBe` [True]) conn
 

--- a/src/Opaleye/Internal/HaskellDB/PrimQuery.hs
+++ b/src/Opaleye/Internal/HaskellDB/PrimQuery.hs
@@ -97,7 +97,7 @@ data OrderOp = OrderOp { orderDirection :: OrderDirection
                        , orderNulls     :: OrderNulls }
                deriving (Show,Read)
 
-data BoundExpr = Inclusive PrimExpr | Exclusive PrimExpr | PosInfinity | NegInfinity
+data BoundExpr = Bounded PrimExpr | PosInfinity | NegInfinity
                  deriving (Show,Read)
 
 data BoundForm = Closed | Open

--- a/src/Opaleye/Internal/HaskellDB/PrimQuery.hs
+++ b/src/Opaleye/Internal/HaskellDB/PrimQuery.hs
@@ -10,7 +10,7 @@ import qualified Data.List.NonEmpty as NEL
 
 type TableName  = String
 type Attribute  = String
-type Name = String
+type Name       = String
 type Scheme     = [Attribute]
 type Assoc      = [(Attribute,PrimExpr)]
 
@@ -34,7 +34,8 @@ data PrimExpr   = AttrExpr  Symbol
                                     -- here.  Perhaps a special type is
                                     -- needed for insert expressions.
                 | ArrayExpr [PrimExpr] -- ^ ARRAY[..]
-                | RangeExpr BoundExpr BoundExpr
+                | BoundExpr BoundExpr
+                | RangeFormExpr BoundForm BoundForm
                 | ArrayIndex PrimExpr PrimExpr
                 deriving (Read,Show)
 
@@ -97,4 +98,7 @@ data OrderOp = OrderOp { orderDirection :: OrderDirection
                deriving (Show,Read)
 
 data BoundExpr = Inclusive PrimExpr | Exclusive PrimExpr | PosInfinity | NegInfinity
+                 deriving (Show,Read)
+
+data BoundForm = Closed | Open
                  deriving (Show,Read)

--- a/src/Opaleye/Internal/HaskellDB/Sql.hs
+++ b/src/Opaleye/Internal/HaskellDB/Sql.hs
@@ -55,7 +55,6 @@ data SqlExpr = ColumnSqlExpr  SqlColumn
              | CastSqlExpr String SqlExpr
              | DefaultSqlExpr
              | ArraySqlExpr [SqlExpr]
-             | RangeSqlExpr SqlRangeBound SqlRangeBound
   deriving Show
 
 -- | Data type for SQL UPDATE statements.

--- a/src/Opaleye/Internal/HaskellDB/Sql/Default.hs
+++ b/src/Opaleye/Internal/HaskellDB/Sql/Default.hs
@@ -145,7 +145,7 @@ defaultSqlExpr gen expr =
       DefaultInsertExpr -> DefaultSqlExpr
       ArrayExpr es -> ArraySqlExpr (map (sqlExpr gen) es)
       BoundExpr b -> case b of
-          (PQ.Bounded x) -> defaultSqlExpr gen x
+          PQ.Bounded x   -> defaultSqlExpr gen x
           PQ.PosInfinity -> ConstSqlExpr "'infinity'"
           PQ.NegInfinity -> ConstSqlExpr "'-infinity'"
       RangeFormExpr start end -> ConstSqlExpr $ showRangeForm start end

--- a/src/Opaleye/Internal/HaskellDB/Sql/Default.hs
+++ b/src/Opaleye/Internal/HaskellDB/Sql/Default.hs
@@ -144,12 +144,12 @@ defaultSqlExpr gen expr =
       CastExpr typ e1 -> CastSqlExpr typ (sqlExpr gen e1)
       DefaultInsertExpr -> DefaultSqlExpr
       ArrayExpr es -> ArraySqlExpr (map (sqlExpr gen) es)
-      RangeExpr l r -> let bound :: PQ.BoundExpr -> Sql.SqlRangeBound
-                           bound (PQ.Inclusive a) = Sql.Inclusive (sqlExpr gen a)
-                           bound (PQ.Exclusive a) = Sql.Exclusive (sqlExpr gen a)
-                           bound PQ.PosInfinity   = Sql.PosInfinity
-                           bound PQ.NegInfinity   = Sql.NegInfinity
-                        in RangeSqlExpr (bound l) (bound r)
+      BoundExpr b -> case b of
+          (PQ.Inclusive x) -> defaultSqlExpr gen x
+          (PQ.Exclusive x) -> defaultSqlExpr gen x
+          PQ.PosInfinity   -> ConstSqlExpr $ "'infinity'"
+          PQ.NegInfinity   -> ConstSqlExpr $ "'-infinity'"
+      RangeFormExpr start end -> ConstSqlExpr $ showRangeForm start end
       ArrayIndex e1 e2 -> SubscriptSqlExpr (ParensSqlExpr $ sqlExpr gen e1) (ParensSqlExpr $ sqlExpr gen e2)
 
 showBinOp :: BinOp -> String
@@ -267,3 +267,10 @@ escape c = [c]
 -- | Quote binary literals using Postgresql's hex format.
 binQuote :: ByteString -> String
 binQuote s = "E'\\\\x" ++ BS8.unpack (Base16.encode s) ++ "'"
+
+
+showRangeForm :: BoundForm -> BoundForm -> String
+showRangeForm Open   Open   = "'()'"
+showRangeForm Open   Closed = "'(]'"
+showRangeForm Closed Open   = "'[)'"
+showRangeForm Closed Closed = "'[]'"

--- a/src/Opaleye/Internal/HaskellDB/Sql/Default.hs
+++ b/src/Opaleye/Internal/HaskellDB/Sql/Default.hs
@@ -145,10 +145,9 @@ defaultSqlExpr gen expr =
       DefaultInsertExpr -> DefaultSqlExpr
       ArrayExpr es -> ArraySqlExpr (map (sqlExpr gen) es)
       BoundExpr b -> case b of
-          (PQ.Inclusive x) -> defaultSqlExpr gen x
-          (PQ.Exclusive x) -> defaultSqlExpr gen x
-          PQ.PosInfinity   -> ConstSqlExpr $ "'infinity'"
-          PQ.NegInfinity   -> ConstSqlExpr $ "'-infinity'"
+          (PQ.Bounded x) -> defaultSqlExpr gen x
+          PQ.PosInfinity -> ConstSqlExpr "'infinity'"
+          PQ.NegInfinity -> ConstSqlExpr "'-infinity'"
       RangeFormExpr start end -> ConstSqlExpr $ showRangeForm start end
       ArrayIndex e1 e2 -> SubscriptSqlExpr (ParensSqlExpr $ sqlExpr gen e1) (ParensSqlExpr $ sqlExpr gen e2)
 

--- a/src/Opaleye/Internal/HaskellDB/Sql/Print.hs
+++ b/src/Opaleye/Internal/HaskellDB/Sql/Print.hs
@@ -117,18 +117,6 @@ ppTable st = case sqlTableSchemaName st of
   where
     tname = doubleQuotes (text (sqlTableName st))
 
-ppStartBound :: SqlRangeBound -> Doc
-ppStartBound (Inclusive a) = text "'[" <> ppSqlExpr a
-ppStartBound (Exclusive a) = text "'(" <> ppSqlExpr a
-ppStartBound PosInfinity   = text "'(infinity"
-ppStartBound NegInfinity   = text "'(-infinity"
-
-ppEndBound :: SqlRangeBound -> Doc
-ppEndBound (Inclusive a) = ppSqlExpr a <> text "]'"
-ppEndBound (Exclusive a) = ppSqlExpr a <> text ")'"
-ppEndBound PosInfinity   = text "infinity)'"
-ppEndBound NegInfinity   = text "-infinity)'"
-
 ppSqlExpr :: SqlExpr -> Doc
 ppSqlExpr expr =
     case expr of
@@ -147,7 +135,6 @@ ppSqlExpr expr =
       CastSqlExpr typ e      -> text "CAST" <> parens (ppSqlExpr e <+> text "AS" <+> text typ)
       DefaultSqlExpr         -> text "DEFAULT"
       ArraySqlExpr es        -> text "ARRAY" <> brackets (commaH ppSqlExpr es)
-      RangeSqlExpr start end -> (hcat . punctuate comma) [ppStartBound start, ppEndBound end]
       AggrFunSqlExpr f es ord distinct -> text f <> parens (ppSqlDistinct distinct <+> commaH ppSqlExpr es <+> ppOrderBy ord)
       CaseSqlExpr cs el   -> text "CASE" <+> vcat (toList (fmap ppWhen cs))
                              <+> text "ELSE" <+> ppSqlExpr el <+> text "END"

--- a/src/Opaleye/PGTypes.hs
+++ b/src/Opaleye/PGTypes.hs
@@ -151,8 +151,8 @@ pgRange pgEl start end = C.Column . HPQ.FunExpr (showRangeType ([] :: [b])) $
     , HPQ.BoundExpr $ boundVal end
     , HPQ.RangeFormExpr (boundType start) (boundType end) ]
     where
-        boundVal (R.Inclusive a) = HPQ.Inclusive . C.unColumn $ pgEl a
-        boundVal (R.Exclusive a) = HPQ.Exclusive . C.unColumn $ pgEl a
+        boundVal (R.Inclusive a) = HPQ.Bounded . C.unColumn $ pgEl a
+        boundVal (R.Exclusive a) = HPQ.Bounded . C.unColumn $ pgEl a
         boundVal R.NegInfinity   = HPQ.NegInfinity
         boundVal R.PosInfinity   = HPQ.PosInfinity
 


### PR DESCRIPTION
I found that solving the issue in a satisfactory, non-hacky way required changing the representation in `PrimExpr`, as we need to express a single bound as a function argument, rather than expressing the whole range together. Particularly since `pgRange` is what knows about the name of the range type/constructor functions.

Fixes #377 