### PR TITLE
"liesWithin" predicate function for ranges

### DIFF
--- a/Test/Test.hs
+++ b/Test/Test.hs
@@ -889,6 +889,8 @@ testRangeDateOverlap = it "generates time overlap" $ \conn -> do
         qOverlap r = A.pure $ r `O.overlap` rangeNow
     testH (qOverlap range1) (`shouldBe` [True]) conn
     testH (qOverlap range2) (`shouldBe` [True]) conn
+    testH (A.pure $ O.pgUTCTime now   `O.liesWithin` range1) (`shouldBe` [True]) conn
+    testH (A.pure $ O.pgUTCTime later `O.liesWithin` range1) (`shouldBe` [False]) conn
 
 testRangeLeftOf :: Test
 testRangeLeftOf = it "generates 'left of'" $ testH q (`shouldBe` [True])

--- a/src/Opaleye/Operators.hs
+++ b/src/Opaleye/Operators.hs
@@ -331,6 +331,9 @@ index (Column a) (Column b) = Column (HPQ.ArrayIndex a b)
 overlap :: Column (T.PGRange a) -> Column (T.PGRange a) -> Column T.PGBool
 overlap = C.binOp (HPQ.:&&)
 
+liesWithin :: T.IsRangeType a => Column a -> Column (T.PGRange a) -> Column T.PGBool
+liesWithin = C.binOp (HPQ.:<@)
+
 infix 4 .<<
 (.<<) :: Column (T.PGRange a) -> Column (T.PGRange a) -> Column T.PGBool
 (.<<) = C.binOp (HPQ.:<<)


### PR DESCRIPTION
This adds a function that tests whether a value lies within a range.

Currently this requires checking overlap with a trivial range consisting of two identical inclusive bounds, which isn't the best user experience. For me this is motivated because we're using temporal tables, so we often need to find a record associated with a particular time. Being able to do that without extra ceremony is valuable, and it's nice to get that out of the box.

The name `liesWithin` is my best idea for something that isn't likely to be confused with any other kind of inclusion test.

Its interesting that this is expressed in Postgres the exact same way as the JSON inclusion tests (`<@` and `@>`). It might be nice if the same operators could be used, but the overloading there seems pretty ad hoc, so maybe we shouldn't inherit it.