### PR TITLE
Numeric Support

### DIFF
--- a/opaleye.cabal
+++ b/opaleye.cabal
@@ -38,6 +38,7 @@ library
     , pretty              >= 1.1.1.0 && < 1.2
     , product-profunctors >= 0.6.2   && < 0.10
     , profunctors         >= 4.0     && < 5.3
+    , scientific          >= 0.3     && < 0.4
     , semigroups          >= 0.13    && < 0.19
     , text                >= 0.11    && < 1.3
     , transformers        >= 0.3     && < 0.6

--- a/src/Opaleye/Constant.hs
+++ b/src/Opaleye/Constant.hs
@@ -13,6 +13,7 @@ import qualified Data.Text                       as ST
 import qualified Data.Text.Lazy                  as LT
 import qualified Data.ByteString                 as SBS
 import qualified Data.ByteString.Lazy            as LBS
+import qualified Data.Scientific                 as Sci
 import qualified Data.Time                       as Time
 import qualified Data.UUID                       as UUID
 
@@ -72,6 +73,9 @@ instance D.Default Constant ST.Text (Column T.PGText) where
 
 instance D.Default Constant LT.Text (Column T.PGText) where
   def = Constant T.pgLazyText
+
+instance D.Default Constant Sci.Scientific (Column T.PGNumeric) where
+  def = Constant T.pgNumeric
 
 instance D.Default Constant Int (Column T.PGInt4) where
   def = Constant T.pgInt4
@@ -143,8 +147,8 @@ instance D.Default Constant (R.PGRange Int.Int) (Column (T.PGRange T.PGInt4)) wh
 instance D.Default Constant (R.PGRange Int.Int64) (Column (T.PGRange T.PGInt8)) where
   def = Constant $ \(R.PGRange a b) -> T.pgRange T.pgInt8 a b
 
--- TODO
---instance D.Default Constant (R.PGRange _) (Column (T.PGRange PGNumeric)) where
+instance D.Default Constant (R.PGRange Sci.Scientific) (Column (T.PGRange T.PGNumeric)) where
+  def = Constant $ \(R.PGRange a b) -> T.pgRange T.pgNumeric a b
 
 instance D.Default Constant (R.PGRange Time.LocalTime) (Column (T.PGRange T.PGTimestamp)) where
   def = Constant $ \(R.PGRange a b) -> T.pgRange T.pgLocalTime a b

--- a/src/Opaleye/Internal/HaskellDB/PrimQuery.hs
+++ b/src/Opaleye/Internal/HaskellDB/PrimQuery.hs
@@ -7,6 +7,7 @@ module Opaleye.Internal.HaskellDB.PrimQuery where
 import qualified Opaleye.Internal.Tag as T
 import Data.ByteString (ByteString)
 import qualified Data.List.NonEmpty as NEL
+import qualified Data.Scientific as Sci
 
 type TableName  = String
 type Attribute  = String
@@ -45,6 +46,7 @@ data Literal = NullLit
              | ByteStringLit ByteString
              | IntegerLit Integer
              | DoubleLit Double
+             | NumericLit Sci.Scientific
              | OtherLit String       -- ^ used for hacking in custom SQL
                deriving (Read,Show)
 

--- a/src/Opaleye/Internal/HaskellDB/Sql/Default.hs
+++ b/src/Opaleye/Internal/HaskellDB/Sql/Default.hs
@@ -16,6 +16,10 @@ import Data.ByteString (ByteString)
 import qualified Data.ByteString.Char8 as BS8
 import qualified Data.ByteString.Base16 as Base16
 import qualified Data.List.NonEmpty as NEL
+import qualified Data.Text.Lazy.Builder.Scientific as Sci
+import qualified Data.Text.Lazy as LT
+import qualified Data.Text.Lazy.Builder as LT
+
 
 mkSqlGenerator :: SqlGenerator -> SqlGenerator
 mkSqlGenerator gen = SqlGenerator
@@ -239,6 +243,7 @@ defaultSqlLiteral _ l =
                        else if isInfinite d && d < 0 then "'-Infinity'"
                        else if isInfinite d && d > 0 then "'Infinity'"
                        else show d
+      NumericLit n  -> LT.unpack . LT.toLazyText . Sci.scientificBuilder $ n
       OtherLit o    -> o
 
 

--- a/src/Opaleye/Internal/RunQuery.hs
+++ b/src/Opaleye/Internal/RunQuery.hs
@@ -32,6 +32,7 @@ import qualified Data.Text.Lazy as LT
 import qualified Data.ByteString as SBS
 import qualified Data.ByteString.Lazy as LBS
 import qualified Data.Time as Time
+import qualified Data.Scientific as Sci
 import qualified Data.String as String
 import           Data.UUID (UUID)
 import           GHC.Int (Int32, Int64)
@@ -158,6 +159,9 @@ instance QueryRunnerColumnDefault a b =>
 -- You can also add a 'FromField' instance using this.
 class QueryRunnerColumnDefault pgType haskellType where
   queryRunnerColumnDefault :: QueryRunnerColumn pgType haskellType
+
+instance QueryRunnerColumnDefault T.PGNumeric Sci.Scientific where
+  queryRunnerColumnDefault = fieldQueryRunnerColumn
 
 instance QueryRunnerColumnDefault T.PGInt4 Int where
   queryRunnerColumnDefault = fieldQueryRunnerColumn

--- a/src/Opaleye/PGTypes.hs
+++ b/src/Opaleye/PGTypes.hs
@@ -19,6 +19,7 @@ import qualified Data.Text as SText
 import qualified Data.Text.Lazy as LText
 import qualified Data.ByteString as SByteString
 import qualified Data.ByteString.Lazy as LByteString
+import           Data.Scientific as Sci
 import qualified Data.Time as Time
 import qualified Data.UUID as UUID
 
@@ -39,6 +40,7 @@ instance C.PGFractional PGFloat8 where
   pgFromRational = pgDouble . fromRational
 
 instance C.PGIntegral PGInt2
+instance C.PGIntegral PGNumeric
 instance C.PGIntegral PGInt4
 instance C.PGIntegral PGInt8
 
@@ -64,6 +66,9 @@ pgStrictText = IPT.literalColumn . HPQ.StringLit . SText.unpack
 
 pgLazyText :: LText.Text -> Column PGText
 pgLazyText = IPT.literalColumn . HPQ.StringLit . LText.unpack
+
+pgNumeric :: Sci.Scientific -> Column PGNumeric
+pgNumeric = IPT.literalColumn . HPQ.NumericLit
 
 pgInt4 :: Int -> Column PGInt4
 pgInt4 = IPT.literalColumn . HPQ.IntegerLit . fromIntegral


### PR DESCRIPTION
Attempt to address #230 

It's difficult to read through the confusion in #230 to figure out what the highlighted concerns were, but I'm just following the lead from `postgresql-simple` here and using the `Scientific` type. My actual use case is  storing 32-byte unsigned integers, which I'm able to do now with tests passing using the following newtype in my application code.

```haskell
newtype Value =
  Value { unValue :: Integer }
    deriving (Eq, Show, Enum, Num, Ord, Real, Integral)

instance QueryRunnerColumnDefault PGNumeric Value where
  queryRunnerColumnDefault = Value . truncate . toRational <$> fieldQueryRunnerColumn @Scientific

instance Default Constant Value (Column PGNumeric) where
  def = Constant $ constant @Scientific . fromInteger . unValue
```

I understand that "unbounded" integers are probably a common usecase, so if you want I can put them in this pr as well.