### PR TITLE
Support DISTINCT ON

### DIFF
--- a/Test/Test.hs
+++ b/Test/Test.hs
@@ -1,43 +1,37 @@
-{-# LANGUAGE Arrows #-}
-{-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE Arrows              #-}
+{-# LANGUAGE FlexibleContexts    #-}
+{-# LANGUAGE OverloadedStrings   #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
 module Main where
 
-import qualified QuickCheck
-import qualified TypeFamilies ()
-
-import           Opaleye (Column, Nullable, Query, QueryArr, (.==), (.>))
-import qualified Opaleye as O
-import qualified Opaleye.Internal.Aggregate as IA
-
-import qualified Database.PostgreSQL.Simple as PGS
+import qualified Configuration.Dotenv             as Dotenv
+import           Control.Applicative              ((<$>), (<*>), (<|>))
+import qualified Control.Applicative              as A
+import           Control.Arrow                    ((&&&), (***), (<<<), (>>>))
+import qualified Control.Arrow                    as Arr
+import qualified Data.Aeson                       as Json
+import qualified Data.Function                    as F
+import qualified Data.List                        as L
+import           Data.Monoid                      ((<>))
+import qualified Data.Ord                         as Ord
+import qualified Data.Profunctor                  as P
+import qualified Data.Profunctor.Product          as PP
+import qualified Data.Profunctor.Product.Default  as D
+import qualified Data.String                      as String
+import qualified Data.Text                        as T
+import qualified Data.Time                        as Time
+import qualified Database.PostgreSQL.Simple       as PGS
 import qualified Database.PostgreSQL.Simple.Range as R
-import qualified Data.Profunctor.Product.Default as D
-import qualified Data.Profunctor.Product as PP
-import qualified Data.Profunctor as P
-import qualified Data.Ord as Ord
-import qualified Data.List as L
-import           Data.Monoid ((<>))
-import qualified Data.String as String
-import qualified Data.Time   as Time
-import qualified Data.Aeson as Json
-import qualified Data.Text as T
-import qualified Data.Function as F
-
-import           System.Environment (lookupEnv)
-
-import           Control.Applicative ((<$>), (<*>), (<|>))
-import qualified Control.Applicative as A
-import qualified Control.Arrow as Arr
-import           Control.Arrow ((&&&), (***), (<<<), (>>>))
-
-import           GHC.Int (Int64)
-
-import Test.Hspec
-
-import qualified Configuration.Dotenv as Dotenv
+import           GHC.Int                          (Int64)
+import           Opaleye                          (Column, Nullable, Query,
+                                                   QueryArr, (.==), (.>))
+import qualified Opaleye                          as O
+import qualified Opaleye.Internal.Aggregate       as IA
+import qualified QuickCheck
+import           System.Environment               (lookupEnv)
+import           Test.Hspec
+import qualified TypeFamilies                     ()
 
 {-
 

--- a/src/Opaleye/Internal/Optimize.hs
+++ b/src/Opaleye/Internal/Optimize.hs
@@ -41,7 +41,7 @@ removeEmpty = PQ.foldPrimQuery PQ.PrimQueryFold {
                                                =<< T.sequence x)
                                       <*> pure y
   , PQ.aggregate = fmap . PQ.Aggregate
-  , PQ.order     = fmap . PQ.Order
+  , PQ.distinctOnOrderBy = \mDistinctOns -> fmap . PQ.DistinctOnOrderBy mDistinctOns
   , PQ.limit     = fmap . PQ.Limit
   , PQ.join      = \jt pe pes1 pes2 pq1 pq2 -> PQ.Join jt pe pes1 pes2 <$> pq1 <*> pq2
   , PQ.existsf   = \b pq1 pq2 -> PQ.Exists b <$> pq1 <*> pq2

--- a/src/Opaleye/Internal/Order.hs
+++ b/src/Opaleye/Internal/Order.hs
@@ -1,19 +1,19 @@
 module Opaleye.Internal.Order where
 
-import           Data.Function (on)
-import qualified Data.Functor.Contravariant as C
+import           Data.Function                        (on)
+import qualified Data.Functor.Contravariant           as C
 import qualified Data.Functor.Contravariant.Divisible as Divisible
-import qualified Data.List.NonEmpty as NL
-import qualified Data.Monoid as M
-import qualified Data.Profunctor as P
-import qualified Data.Semigroup as S
-import qualified Data.Void as Void
-import qualified Opaleye.Column as C
-import qualified Opaleye.Internal.Column as IC
+import qualified Data.List.NonEmpty                   as NL
+import qualified Data.Monoid                          as M
+import qualified Data.Profunctor                      as P
+import qualified Data.Semigroup                       as S
+import qualified Data.Void                            as Void
+import qualified Opaleye.Column                       as C
+import qualified Opaleye.Internal.Column              as IC
 import qualified Opaleye.Internal.HaskellDB.PrimQuery as HPQ
-import qualified Opaleye.Internal.PrimQuery as PQ
-import qualified Opaleye.Internal.Tag as T
-import qualified Opaleye.Internal.Unpackspec as U
+import qualified Opaleye.Internal.PrimQuery           as PQ
+import qualified Opaleye.Internal.Tag                 as T
+import qualified Opaleye.Internal.Unpackspec          as U
 
 {-|
 An `Order` @a@ represents a sort order and direction for the elements

--- a/src/Opaleye/Internal/Order.hs
+++ b/src/Opaleye/Internal/Order.hs
@@ -1,21 +1,19 @@
 module Opaleye.Internal.Order where
 
 import           Data.Function (on)
-
-import qualified Data.List.NonEmpty as NL
-
-import qualified Opaleye.Column as C
-import qualified Opaleye.Internal.Column as IC
-import qualified Opaleye.Internal.Tag as T
-import qualified Opaleye.Internal.PrimQuery as PQ
-
-import qualified Opaleye.Internal.HaskellDB.PrimQuery as HPQ
 import qualified Data.Functor.Contravariant as C
 import qualified Data.Functor.Contravariant.Divisible as Divisible
-import qualified Data.Profunctor as P
+import qualified Data.List.NonEmpty as NL
 import qualified Data.Monoid as M
+import qualified Data.Profunctor as P
 import qualified Data.Semigroup as S
 import qualified Data.Void as Void
+import qualified Opaleye.Column as C
+import qualified Opaleye.Internal.Column as IC
+import qualified Opaleye.Internal.HaskellDB.PrimQuery as HPQ
+import qualified Opaleye.Internal.PrimQuery as PQ
+import qualified Opaleye.Internal.Tag as T
+import qualified Opaleye.Internal.Unpackspec as U
 
 {-|
 An `Order` @a@ represents a sort order and direction for the elements
@@ -55,7 +53,7 @@ order op f = Order (fmap (\column -> [(op, IC.unColumn column)]) f)
 
 orderByU :: Order a -> (a, PQ.PrimQuery, T.Tag) -> (a, PQ.PrimQuery, T.Tag)
 orderByU os (columns, primQ, t) = (columns, primQ', t)
-  where primQ' = PQ.Order oExprs primQ
+  where primQ' = PQ.DistinctOnOrderBy Nothing oExprs primQ
         oExprs = orderExprs columns os
 
 orderExprs :: a -> Order a -> [HPQ.OrderExpr]
@@ -66,6 +64,17 @@ limit' n (x, q, t) = (x, PQ.Limit (PQ.LimitOp n) q, t)
 
 offset' :: Int -> (a, PQ.PrimQuery, T.Tag) -> (a, PQ.PrimQuery, T.Tag)
 offset' n (x, q, t) = (x, PQ.Limit (PQ.OffsetOp n) q, t)
+
+distinctOn :: U.Unpackspec b b -> (a -> b)
+           -> (a, PQ.PrimQuery, T.Tag) -> (a, PQ.PrimQuery, T.Tag)
+distinctOn ups proj = distinctOnBy ups proj (Order $ const [])
+
+distinctOnBy :: U.Unpackspec b b -> (a -> b) -> Order a
+             -> (a, PQ.PrimQuery, T.Tag) -> (a, PQ.PrimQuery, T.Tag)
+distinctOnBy ups proj ord (cols, pq, t) = (cols, pqOut, t)
+    where pqOut = case U.collectPEs ups (proj cols) of
+            x:xs -> PQ.DistinctOnOrderBy (Just $ x NL.:| xs) (orderExprs cols ord) pq
+            []   -> pq
 
 -- | Order the results of a given query exactly, as determined by the given list
 -- of input columns. Note that this list does not have to contain an entry for

--- a/src/Opaleye/Internal/PrimQuery.hs
+++ b/src/Opaleye/Internal/PrimQuery.hs
@@ -45,7 +45,11 @@ data PrimQuery' a = Unit
                   | Product   (NEL.NonEmpty (PrimQuery' a)) [HPQ.PrimExpr]
                   | Aggregate (Bindings (Maybe (HPQ.AggrOp, [HPQ.OrderExpr], HPQ.AggrDistinct), HPQ.PrimExpr))
                               (PrimQuery' a)
-                  | Order     [HPQ.OrderExpr] (PrimQuery' a)
+                  -- | Represents both @DISTINCT ON@ and @ORDER BY@ clauses. In order to represent valid
+                  --   SQL only, @DISTINCT ON@ expressions are always interpreted as the first @ORDER BY@s
+                  --   when present, preceding any in the provided list.
+                  --   See 'Opaleye.Internal.Sql.distinctOnOrderBy'.
+                  | DistinctOnOrderBy (Maybe (NEL.NonEmpty HPQ.PrimExpr)) [HPQ.OrderExpr] (PrimQuery' a)
                   | Limit     LimitOp (PrimQuery' a)
                   | Join      JoinType
                               HPQ.PrimExpr
@@ -66,62 +70,62 @@ type PrimQuery = PrimQuery' ()
 type PrimQueryFold = PrimQueryFold' ()
 
 data PrimQueryFold' a p = PrimQueryFold
-  { unit      :: p
-  , empty     :: a -> p
-  , baseTable :: TableIdentifier -> Bindings HPQ.PrimExpr -> p
-  , product   :: NEL.NonEmpty p -> [HPQ.PrimExpr] -> p
-  , aggregate :: Bindings (Maybe (HPQ.AggrOp, [HPQ.OrderExpr], HPQ.AggrDistinct), HPQ.PrimExpr) -> p -> p
-  , order     :: [HPQ.OrderExpr] -> p -> p
-  , limit     :: LimitOp -> p -> p
-  , join      :: JoinType
-              -> HPQ.PrimExpr
-              -> Bindings HPQ.PrimExpr
-              -> Bindings HPQ.PrimExpr
-              -> p
-              -> p
-              -> p
-  , existsf   :: Bool -> p -> p -> p
-  , values    :: [Symbol] -> NEL.NonEmpty [HPQ.PrimExpr] -> p
-  , binary    :: BinOp -> Bindings (HPQ.PrimExpr, HPQ.PrimExpr) -> (p, p) -> p
-  , label     :: String -> p -> p
-  , relExpr   :: HPQ.PrimExpr -> Bindings HPQ.PrimExpr -> p
+  { unit              :: p
+  , empty             :: a -> p
+  , baseTable         :: TableIdentifier -> Bindings HPQ.PrimExpr -> p
+  , product           :: NEL.NonEmpty p -> [HPQ.PrimExpr] -> p
+  , aggregate         :: Bindings (Maybe (HPQ.AggrOp, [HPQ.OrderExpr], HPQ.AggrDistinct), HPQ.PrimExpr) -> p -> p
+  , distinctOnOrderBy :: Maybe (NEL.NonEmpty HPQ.PrimExpr) -> [HPQ.OrderExpr] -> p -> p
+  , limit             :: LimitOp -> p -> p
+  , join              :: JoinType
+                      -> HPQ.PrimExpr
+                      -> Bindings HPQ.PrimExpr
+                      -> Bindings HPQ.PrimExpr
+                      -> p
+                      -> p
+                      -> p
+  , existsf           :: Bool -> p -> p -> p
+  , values            :: [Symbol] -> NEL.NonEmpty [HPQ.PrimExpr] -> p
+  , binary            :: BinOp -> Bindings (HPQ.PrimExpr, HPQ.PrimExpr) -> (p, p) -> p
+  , label             :: String -> p -> p
+  , relExpr           :: HPQ.PrimExpr -> Bindings HPQ.PrimExpr -> p
     -- ^ A relation-valued expression
   }
 
 
 primQueryFoldDefault :: PrimQueryFold' a (PrimQuery' a)
 primQueryFoldDefault = PrimQueryFold
-  { unit      = Unit
-  , empty     = Empty
-  , baseTable = BaseTable
-  , product   = Product
-  , aggregate = Aggregate
-  , order     = Order
-  , limit     = Limit
-  , join      = Join
-  , values    = Values
-  , binary    = Binary
-  , label     = Label
-  , relExpr   = RelExpr
-  , existsf   = Exists
+  { unit              = Unit
+  , empty             = Empty
+  , baseTable         = BaseTable
+  , product           = Product
+  , aggregate         = Aggregate
+  , distinctOnOrderBy = DistinctOnOrderBy
+  , limit             = Limit
+  , join              = Join
+  , values            = Values
+  , binary            = Binary
+  , label             = Label
+  , relExpr           = RelExpr
+  , existsf           = Exists
   }
 
 foldPrimQuery :: PrimQueryFold' a p -> PrimQuery' a -> p
 foldPrimQuery f = fix fold
   where fold self primQ = case primQ of
-          Unit                      -> unit      f
-          Empty a                   -> empty     f a
-          BaseTable ti syms         -> baseTable f ti syms
-          Product qs pes            -> product   f (fmap self qs) pes
-          Aggregate aggrs q         -> aggregate f aggrs (self q)
-          Order pes q               -> order     f pes (self q)
-          Limit op q                -> limit     f op (self q)
-          Join j cond pe1 pe2 q1 q2 -> join      f j cond pe1 pe2 (self q1) (self q2)
-          Values ss pes             -> values    f ss pes
-          Binary binop pes (q1, q2) -> binary    f binop pes (self q1, self q2)
-          Label l pq                -> label     f l (self pq)
-          RelExpr pe syms           -> relExpr   f pe syms
-          Exists b q1 q2            -> existsf   f b (self q1) (self q2)
+          Unit                        -> unit              f
+          Empty a                     -> empty             f a
+          BaseTable ti syms           -> baseTable         f ti syms
+          Product qs pes              -> product           f (fmap self qs) pes
+          Aggregate aggrs q           -> aggregate         f aggrs (self q)
+          DistinctOnOrderBy dxs oxs q -> distinctOnOrderBy f dxs oxs (self q)
+          Limit op q                  -> limit             f op (self q)
+          Join j cond pe1 pe2 q1 q2   -> join              f j cond pe1 pe2 (self q1) (self q2)
+          Values ss pes               -> values            f ss pes
+          Binary binop pes (q1, q2)   -> binary            f binop pes (self q1, self q2)
+          Label l pq                  -> label             f l (self pq)
+          RelExpr pe syms             -> relExpr           f pe syms
+          Exists b q1 q2              -> existsf           f b (self q1) (self q2)
         fix g = let x = g x in x
 
 times :: PrimQuery -> PrimQuery -> PrimQuery

--- a/src/Opaleye/Internal/Print.hs
+++ b/src/Opaleye/Internal/Print.hs
@@ -33,9 +33,15 @@ ppSql (SelectBinary v) = ppSelectBinary v
 ppSql (SelectLabel v)  = ppSelectLabel v
 ppSql (SelectExists v) = ppSelectExists v
 
+ppDistinctOn :: Maybe (NEL.NonEmpty HSql.SqlExpr) -> Doc
+ppDistinctOn = maybe mempty $ \nel ->
+    text "DISTINCT ON" <+>
+        text "(" $$ HPrint.commaV HPrint.ppSqlExpr (NEL.toList nel) $$ text ")"
+
 ppSelectFrom :: From -> Doc
 ppSelectFrom s = text "SELECT"
-                 <+> ppAttrs (Sql.attrs s)
+                 <+> ppDistinctOn (Sql.distinctOn s)
+                 $$  ppAttrs (Sql.attrs s)
                  $$  ppTables (Sql.tables s)
                  $$  HPrint.ppWhere (Sql.criteria s)
                  $$  ppGroupBy (Sql.groupBy s)


### PR DESCRIPTION
Resolving #244 

I went with your basic idea of using `Default Unpackspec` as a way to get at the expressions to distinguish. That seems to work nicely! However, the most straightforward implementation turned out not to work due to the interaction of this feature with ordering.

In order for my use case (and most of them I would guess) we need a way to determine which row is selected. It turns out we can't just accomplish this by ordering first, at a deeper nesting. A `DISTINCT ON` query does not respect any ordering except the one provided with it directly. Therefore we need a construct that can perform both of these modifications together.

With that in mind, here are some properties and remarks about what I've implemented currently.

### Exposed API

```haskell
distinctOn   :: Default Unpackspec b b => (a -> b)            -> Select a -> Select a
distinctOnBy :: Default Unpackspec b b => (a -> b) -> Order a -> Select a -> Select a
```

The first function is exactly what we discussed. The second allows us to control the ordering used to choose representative rows from each equivalence class. It differs from the raw SQL in that it does not allow a user to input an invalid query, because any expressions that are distinguished are automatically included as the leftmost ordering expressions. (Obviously this makes no difference, its just fixing a leaking implementation detail)

_Alternative:_ The second function could be called `distinctOnOrderBy` but I fear this would trick someone into believing the _output_ was ordered!

### Internal changes

The main opinionated property here is that I used a single constructor of `PrimQuery` that can represent both ordering and/or `distinct on`. Any constructor that could represent the needed functionality can also represent both sub-features, so I saw no need to keep a duplicate. I also chose a representation that makes bad SQL unrepresentable, namely by interpreting all of the `distinct on` expressions as leftmost `order by _ asc` expressions too. One could argue this implicitness is undesirable, but I think it is less so than allowing to represent invalid queries, and I cannot think of any way this would cause any real issues.