### PR TITLE
Range bound accessors, and fix unbounded ranges

### DIFF
--- a/src/Opaleye/Internal/HaskellDB/Sql/Print.hs
+++ b/src/Opaleye/Internal/HaskellDB/Sql/Print.hs
@@ -138,8 +138,8 @@ ppRange t start end =
   where value_boundTypeT = \case
           Inclusive a -> (Inclusive', a)
           Exclusive a -> (Exclusive', a)
-          PosInfinity -> (Exclusive', ConstSqlExpr "'infinity'")
-          NegInfinity -> (Exclusive', ConstSqlExpr "'-infinity'")
+          PosInfinity -> (Exclusive', ConstSqlExpr "NULL")
+          NegInfinity -> (Exclusive', ConstSqlExpr "NULL")
 
         (startType, startValue) = value_boundTypeT start
         (endType,   endValue)   = value_boundTypeT end

--- a/src/Opaleye/Operators.hs
+++ b/src/Opaleye/Operators.hs
@@ -349,6 +349,14 @@ overlap = C.binOp (HPQ.:&&)
 liesWithin :: T.IsRangeType a => Column a -> Column (T.SqlRange a) -> F.Field T.SqlBool
 liesWithin = C.binOp (HPQ.:<@)
 
+-- | Access the upper bound of a range. For discrete range types it is the exclusive bound.
+upperBound :: T.IsRangeType a => Column (T.SqlRange a) -> Column (C.Nullable a)
+upperBound (Column range) = Column $ HPQ.FunExpr "upper" [range]
+
+-- | Access the lower bound of a range. For discrete range types it is the inclusive bound.
+lowerBound :: T.IsRangeType a => Column (T.SqlRange a) -> Column (C.Nullable a)
+lowerBound (Column range) = Column $ HPQ.FunExpr "lower" [range]
+
 infix 4 .<<
 (.<<) :: Column (T.SqlRange a) -> Column (T.SqlRange a) -> F.Field T.SqlBool
 (.<<) = C.binOp (HPQ.:<<)


### PR DESCRIPTION
This was mainly going to be about adding the two accessor functions for range bounds. They seems like the last "obviously needed" pieces to have a nice range interface.  We've been using `lowerBound` in our repo for a while now.

But when adding the test I noticed that we've had the wrong representation for unbounded ranges. So `infinity` is not actually valid for all ranges, its just a value that inhabits certain types which have ranges. 

Its an easy fix so I just included it in this.

From the [documentation](https://www.postgresql.org/docs/current/static/rangetypes.html): 

> Also, some element types have a notion of "infinity", but that is just another value so far as the range type mechanisms are concerned. For example, in timestamp ranges, [today,] means the same thing as [today,). But [today,infinity] means something different from [today,infinity) — the latter excludes the special timestamp value infinity.