### PR TITLE
Add MINIMAL pragma to IsSqlType class

### DIFF
--- a/src/Opaleye/PGTypes.hs
+++ b/src/Opaleye/PGTypes.hs
@@ -167,6 +167,8 @@ class IsSqlType sqlType where
   showSqlType :: proxy sqlType -> String
   showSqlType = showPGType
 
+  {-# MINIMAL showPGType | showSqlType #-}
+
 instance IsSqlType PGBool where
   showSqlType _ = "boolean"
 instance IsSqlType PGDate where


### PR DESCRIPTION
Both methods have a default implementation, but to be correct one of
them must be implemented.