### PR TITLE
Cast all literals

### DIFF
--- a/Test/Test.hs
+++ b/Test/Test.hs
@@ -886,6 +886,11 @@ testArrayIndexOOB = it "returns Nothing when the index is out of bounds" $
   testH (A.pure $ O.pgArray O.pgInt4 [5,6,7] `O.index` O.pgInt4 8)
         (`shouldBe` ([Nothing] :: [Maybe Int]))
 
+testSingletonArray :: Test
+testSingletonArray = it "constructs a singleton PGInt8 array" $
+  testH (A.pure $ O.singletonArray (O.pgInt8 1))
+        (`shouldBe` ([[1]] :: [[Int64]]))
+
 type JsonTest a = SpecWith (Query (Column a) -> PGS.Connection -> Expectation)
 -- Test opaleye's equivalent of c1->'c'
 testJsonGetFieldValue :: (O.SqlIsJson a, O.QueryRunnerColumnDefault a Json.Value) => Query (Column a) -> Test
@@ -1180,6 +1185,7 @@ main = do
         testFloatArray
         testArrayIndex
         testArrayIndexOOB
+        testSingletonArray
       describe "joins" $ do
         testLeftJoin
         testLeftJoinNullable

--- a/opaleye-sqlite/src/Opaleye/SQLite/PGTypes.hs
+++ b/opaleye-sqlite/src/Opaleye/SQLite/PGTypes.hs
@@ -86,7 +86,7 @@ pgBool :: Bool -> Column PGBool
 pgBool = IPT.literalColumn . HPQ.BoolLit
 
 pgUUID :: UUID.UUID -> Column PGUuid
-pgUUID = C.unsafeCoerceColumn . pgString . UUID.toString
+pgUUID = IPT.literalColumn . HPQ.StringLit . UUID.toString
 
 unsafePgFormatTime :: Time.FormatTime t => HPQ.Name -> String -> t -> Column c
 unsafePgFormatTime = IPT.unsafePgFormatTime

--- a/opaleye.cabal
+++ b/opaleye.cabal
@@ -122,6 +122,7 @@ test-suite test
     semigroups,
     text >= 0.11 && < 1.3,
     time,
+    uuid,
     transformers,
     hspec,
     hspec-discover,

--- a/src/Opaleye/Internal/PGTypes.hs
+++ b/src/Opaleye/Internal/PGTypes.hs
@@ -1,8 +1,12 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+
 module Opaleye.Internal.PGTypes where
 
 import           Opaleye.Internal.Column (Column(Column))
+import qualified Opaleye.Internal.Column as C
 import qualified Opaleye.Internal.HaskellDB.PrimQuery as HPQ
 
+import           Data.Proxy (Proxy(..))
 import qualified Data.Text as SText
 import qualified Data.Text.Encoding as STextEncoding
 import qualified Data.Text.Lazy as LText
@@ -16,8 +20,8 @@ unsafePgFormatTime :: Time.FormatTime t => HPQ.Name -> String -> t -> Column c
 unsafePgFormatTime typeName formatString = castToType typeName . format
   where format = Time.formatTime Locale.defaultTimeLocale formatString
 
-literalColumn :: HPQ.Literal -> Column a
-literalColumn = Column . HPQ.ConstExpr
+literalColumn :: forall a. IsSqlType a => HPQ.Literal -> Column a
+literalColumn = Column . HPQ.CastExpr (showSqlType (Proxy :: Proxy a)) . HPQ.ConstExpr
 
 castToType :: HPQ.Name -> String -> Column c
 castToType typeName =
@@ -28,3 +32,18 @@ strictDecodeUtf8 = SText.unpack . STextEncoding.decodeUtf8
 
 lazyDecodeUtf8 :: LByteString.ByteString -> String
 lazyDecodeUtf8 = LText.unpack . LTextEncoding.decodeUtf8
+
+{-# DEPRECATED showPGType
+    "Use 'showSqlType' instead. 'showPGType' will be removed \
+    \in version 0.7." #-}
+class IsSqlType sqlType where
+  showPGType :: proxy sqlType -> String
+  showPGType  = showSqlType
+
+  showSqlType :: proxy sqlType -> String
+  showSqlType = showPGType
+
+  {-# MINIMAL showPGType | showSqlType #-}
+
+instance IsSqlType a => IsSqlType (C.Nullable a) where
+  showSqlType _ = showSqlType (Proxy :: Proxy a)

--- a/src/Opaleye/PGTypes.hs
+++ b/src/Opaleye/PGTypes.hs
@@ -84,7 +84,7 @@ pgBool :: Bool -> Column PGBool
 pgBool = IPT.literalColumn . HPQ.BoolLit
 
 pgUUID :: UUID.UUID -> Column PGUuid
-pgUUID = C.unsafeCoerceColumn . pgString . UUID.toString
+pgUUID = IPT.literalColumn . HPQ.StringLit . UUID.toString
 
 pgDay :: Time.Day -> Column PGDate
 pgDay = IPT.unsafePgFormatTime "date" "'%F'"

--- a/src/Opaleye/PGTypes.hs
+++ b/src/Opaleye/PGTypes.hs
@@ -242,8 +242,8 @@ data PGRange a
 
 -- * Deprecated functions
 
-literalColumn :: IsSqlType a => HPQ.Literal -> Column a
-literalColumn = IPT.literalColumn
+literalColumn :: HPQ.Literal -> Column a
+literalColumn = C.Column . HPQ.ConstExpr
 {-# DEPRECATED literalColumn
     "'literalColumn' has been moved to Opaleye.Internal.PGTypes and will be removed in version 0.7."
   #-}

--- a/src/Opaleye/PGTypes.hs
+++ b/src/Opaleye/PGTypes.hs
@@ -4,11 +4,12 @@
 {-# LANGUAGE EmptyDataDecls #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
-module Opaleye.PGTypes (module Opaleye.PGTypes) where
+module Opaleye.PGTypes (module Opaleye.PGTypes, IsSqlType(..)) where
 
 import           Opaleye.Internal.Column (Column)
 import qualified Opaleye.Internal.Column as C
 import qualified Opaleye.Internal.PGTypes as IPT
+import           Opaleye.Internal.PGTypes (IsSqlType(..))
 
 import qualified Opaleye.Internal.HaskellDB.PrimQuery as HPQ
 import qualified Opaleye.Internal.HaskellDB.Sql.Default as HSD
@@ -157,18 +158,6 @@ pgRange pgEl start end = C.Column (HPQ.RangeExpr (showRangeType ([] :: [b])) (on
         oneEl R.NegInfinity   = HPQ.NegInfinity
         oneEl R.PosInfinity   = HPQ.PosInfinity
 
-{-# DEPRECATED showPGType
-    "Use 'showSqlType' instead. 'showPGType' will be removed \
-    \in version 0.7." #-}
-class IsSqlType sqlType where
-  showPGType :: proxy sqlType -> String
-  showPGType  = showSqlType
-
-  showSqlType :: proxy sqlType -> String
-  showSqlType = showPGType
-
-  {-# MINIMAL showPGType | showSqlType #-}
-
 instance IsSqlType PGBool where
   showSqlType _ = "boolean"
 instance IsSqlType PGDate where
@@ -201,8 +190,6 @@ instance IsSqlType PGBytea where
   showSqlType _ = "bytea"
 instance IsSqlType a => IsSqlType (PGArray a) where
   showSqlType _ = showSqlType ([] :: [a]) ++ "[]"
-instance IsSqlType a => IsSqlType (C.Nullable a) where
-  showSqlType _ = showSqlType ([] :: [a])
 instance IsSqlType PGJson where
   showSqlType _ = "json"
 instance IsSqlType PGJsonb where
@@ -255,7 +242,7 @@ data PGRange a
 
 -- * Deprecated functions
 
-literalColumn :: HPQ.Literal -> Column a
+literalColumn :: IsSqlType a => HPQ.Literal -> Column a
 literalColumn = IPT.literalColumn
 {-# DEPRECATED literalColumn
     "'literalColumn' has been moved to Opaleye.Internal.PGTypes and will be removed in version 0.7."


### PR DESCRIPTION
This patch makes Opaleye add an explicit `CAST` to SQL literals. This is to force Postgres to assign the type we want to the expression.

Not doing this caused problems in the past, as Postgres's automatic type conversion did not always work as expected (and we shouldn't rely on it anyway, since we have all type information statically).

Fixes #253, #410 

Notes:
- I had to change `Opaleye.PGTypes.literalColumn` to have the original definition, because the new `literalColumn` requires an additional constraint.
- `sqlUUID` had to be adjusted, because it relied on `pgString`, generating a cast to `text` instead of the expected `uuid`