### PR TITLE
Type Family style template haskell

### DIFF
--- a/Test/TypeFamilyTH.hs
+++ b/Test/TypeFamilyTH.hs
@@ -1,15 +1,15 @@
-{-# LANGUAGE FlexibleContexts      #-}
-{-# LANGUAGE FlexibleInstances     #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE TemplateHaskell       #-}
-{-# LANGUAGE TypeFamilies          #-}
-{-# LANGUAGE UndecidableInstances  #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
 
-module Main where
+module TypeFamilyTH where
 
-import           Opaleye.Internal.TypeFamilies
-import           Opaleye.Internal.TypeFamiliesTH
-import           Opaleye.SqlTypes
+import Opaleye.Internal.TypeFamilies
+import Opaleye.Internal.TypeFamiliesTH
+import Opaleye.SqlTypes
 
 
 data UserP f = UserP
@@ -27,8 +27,3 @@ data ResultP f = Result
     }
 
 makeTableAdaptorInstanceMap "pResult" ''ResultP
-
-
--- If this compiles, this works
-main :: IO ()
-main = return ()

--- a/Test/TypeFamilyTH.hs
+++ b/Test/TypeFamilyTH.hs
@@ -1,0 +1,34 @@
+{-# LANGUAGE FlexibleContexts      #-}
+{-# LANGUAGE FlexibleInstances     #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE TemplateHaskell       #-}
+{-# LANGUAGE TypeFamilies          #-}
+{-# LANGUAGE UndecidableInstances  #-}
+
+module Main where
+
+import           Opaleye.Internal.TypeFamilies
+import           Opaleye.Internal.TypeFamiliesTH
+import           Opaleye.SqlTypes
+
+
+data UserP f = UserP
+    { pName      :: TableField f String SqlText NN Req
+    , pUserEmail :: TableField f String SqlText NN Req
+    , pEnabled   :: TableField f Bool   SqlBool NN Opt
+    }
+
+makeTableAdaptorInstanceMap "pUser" ''UserP
+
+
+data ResultP f = Result
+    { rName    :: RecordField f String SqlText NN
+    , rMessage :: RecordField f String SqlText NN
+    }
+
+makeTableAdaptorInstanceMap "pResult" ''ResultP
+
+
+-- If this compiles, this works
+main :: IO ()
+main = return ()

--- a/opaleye.cabal
+++ b/opaleye.cabal
@@ -41,6 +41,7 @@ library
     , scientific          >= 0.3     && < 0.4
     , semigroups          >= 0.13    && < 0.20
     , text                >= 0.11    && < 1.3
+    , template-haskell    >= 2.10    && < 2.15
     , transformers        >= 0.3     && < 0.6
     , time                >= 1.4     && < 1.10
     , time-locale-compat  >= 0.1     && < 0.2
@@ -92,6 +93,7 @@ library
                    Opaleye.Internal.TableMaker,
                    Opaleye.Internal.Tag,
                    Opaleye.Internal.TypeFamilies,
+                   Opaleye.Internal.TypeFamiliesTH,
                    Opaleye.Internal.Unpackspec,
                    Opaleye.Internal.Values
                    Opaleye.Internal.HaskellDB.PrimQuery,

--- a/opaleye.cabal
+++ b/opaleye.cabal
@@ -108,7 +108,8 @@ test-suite test
   type: exitcode-stdio-1.0
   main-is: Test.hs
   other-modules: QuickCheck,
-                 TypeFamilies
+                 TypeFamilies,
+                 TypeFamilyTH
   hs-source-dirs: Test
   build-depends:
     aeson >= 0.6 && < 1.5,

--- a/src/Opaleye/Internal/TypeFamiliesTH.hs
+++ b/src/Opaleye/Internal/TypeFamiliesTH.hs
@@ -1,0 +1,177 @@
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeOperators #-}
+
+module Opaleye.Internal.TypeFamiliesTH (makeTableAdaptorInstanceMap) where
+
+import Data.List (foldl', nub)
+import Data.Maybe (listToMaybe, mapMaybe)
+import Data.Profunctor.Product (ProductProfunctor)
+import Data.Profunctor.Product.Default (Default (..))
+import Data.Profunctor.Product.Internal.TH (adaptorDefinition, adaptorDefinitionFields)
+import Language.Haskell.TH
+import Opaleye.Internal.TypeFamilies ((:<$>), (:<*>), F, IMap, TableField)
+import Opaleye.Map (Map)
+
+
+type DefaultTable h o n r p a b = Default p (TableField a h o n r) (TableField b h o n r)
+
+
+-- Taken, slightly modified, from product-profunctors makeAdaptorAndInstance
+data ConTysFields
+    = ConTys   [Type]         -- ^^ The type of each constructor field
+    | FieldTys [(Name, Type)] -- ^^ The fieldname and type of each constructor field
+    deriving Show
+
+
+fieldTypes :: ConTysFields -> [Type]
+fieldTypes (ConTys ts)   = ts
+fieldTypes (FieldTys xs) = map snd xs
+
+
+data DataDecInfo = DataDecInfo
+    { dTyName  :: Name
+    , dTyVars  :: [Name]
+    , dConName :: Name
+    , dConTys  :: ConTysFields
+    } deriving Show
+
+
+dataDec :: Info -> Q DataDecInfo
+dataDec (TyConI (DataD _ tyName tyVars _ constructors _))   = dataDecInfo tyName tyVars constructors
+dataDec (TyConI (NewtypeD _ tyName tyVars _ constructor _)) = dataDecInfo tyName tyVars [constructor]
+dataDec _                                                   = fail "Not a data or newtype declaration"
+
+
+dataDecInfo :: Name -> [TyVarBndr] -> [Con] -> Q DataDecInfo
+dataDecInfo tyName tyVars constructors = do
+    (conName, conTys) <- conInfo =<< onlyOneConstructor constructors
+    return DataDecInfo
+        { dTyName  = tyName
+        , dTyVars  = map varNameOfBinder tyVars
+        , dConName = conName
+        , dConTys  = conTys
+        }
+  where
+    varNameOfBinder :: TyVarBndr -> Name
+    varNameOfBinder (PlainTV n)    = n
+    varNameOfBinder (KindedTV n _) = n
+
+    onlyOneConstructor [con] = return con
+    onlyOneConstructor _     = fail "Can only handle one constructor"
+
+    conInfo (NormalC cn st) = return (cn, ConTys $ map snd st)
+    conInfo (RecC cn vst)   = return (cn, FieldTys $ map (\(n, _, t) -> (n, t)) vst)
+    conInfo _               = fail "Cannot handle constructor type"
+
+
+findTableFieldTypeName :: ConTysFields -> Q Name
+findTableFieldTypeName = firstInstance (fail "Could not find TableField") findTableFieldApp . fieldTypes
+  where
+    findTableFieldApp (AppT (ConT t) (VarT x)) | t == ''TableField = Just x
+    findTableFieldApp (AppT f _)               = findTableFieldApp f
+    findTableFieldApp _                        = Nothing
+
+    firstInstance err f = maybe err return . listToMaybe . mapMaybe f
+
+
+appTTableField :: Name -> [Name] -> ConTysFields -> Type -> Q Type
+appTTableField tyName args fieldTys t = do
+    f <- varT =<< findTableFieldTypeName fieldTys
+    appTAll (ConT tyName) . replaceFirst f t <$> mapM varT args
+  where
+    replaceFirst _ _ [] = []
+    replaceFirst x y (z:zs)
+        | z == x    = y:zs
+        | otherwise = z:replaceFirst x y zs
+
+
+appTAll :: Type -> [Type] -> Type
+appTAll = foldl' AppT
+
+
+appEAll :: ExpQ -> [ExpQ] -> ExpQ
+appEAll = foldl' appE
+
+
+-- | Make adaptors and type families instances for TypeFamilies style Opaleye tables types.
+makeTableAdaptorInstanceMap :: String -> Name -> Q [Dec]
+makeTableAdaptorInstanceMap adaptorName consName =
+    reify consName >>= dataDec >>= tableAdaptorInstanceMap (mkName adaptorName)
+
+
+tableAdaptorInstanceMap :: Name -> DataDecInfo -> Q [Dec]
+tableAdaptorInstanceMap adaptorName info = sequence
+    [ adaptorSig adaptorName info
+    , adaptorDef adaptorName info
+    , instanceDef adaptorName info
+    , mapTypeInstance info
+    ]
+
+
+p :: TypeQ
+p = varT $ mkName "p"
+
+
+a :: TypeQ
+a = varT $ mkName "a"
+
+
+b :: TypeQ
+b = varT $ mkName "b"
+
+
+adaptorSig :: Name -> DataDecInfo -> Q Dec
+adaptorSig adaptorName DataDecInfo{dTyName, dTyVars, dConTys} = SigD adaptorName <$> adaptorType
+  where
+    app = appTTableField dTyName dTyVars dConTys
+
+    adaptorType = [t| ProductProfunctor $p => $before -> $after |]
+    before = app =<< [t| $p :<$> $a :<*> $b |]
+    after = [t| $p $(app =<< a) $(app =<< b) |]
+
+
+adaptorDef :: Name -> DataDecInfo -> Q Dec
+adaptorDef adaptorName DataDecInfo{dConName, dTyVars, dConTys} = return $ fieldTypeAdaptorDef dConTys adaptorName
+  where
+    numTyVars = length dTyVars
+    fieldTypeAdaptorDef (ConTys _)          = adaptorDefinition numTyVars dConName
+    fieldTypeAdaptorDef (FieldTys fieldTys) = adaptorDefinitionFields dConName fieldTys
+
+
+instanceDef :: Name -> DataDecInfo -> Q Dec
+instanceDef adaptorName DataDecInfo{dTyName, dTyVars, dConName, dConTys} = instanceD ctxt instType [defDef]
+  where
+    app = appTTableField dTyName dTyVars dConTys
+
+    ctxt = (:) <$> [t| ProductProfunctor $p |] <*> defaultTableCxt
+    defaultTableCxt = nub <$> mapM defaultTableConstraint (fieldTypes dConTys)
+
+    instType = [t| Default $p $(app =<< a) $(app =<< b) |]
+
+    defDef = funD 'def [clause [] defBody []]
+
+    numConVars = length $ fieldTypes dConTys
+    defs = replicate numConVars (varE 'def)
+    defBody = normalB [| $(varE adaptorName) $(appEAll (conE dConName) defs) |]
+
+
+defaultTableConstraint :: Type -> Q Type
+defaultTableConstraint (AppT (AppT (AppT (AppT (AppT (ConT tf) _) h) o) n) r)
+    | tf == ''TableField = [t| DefaultTable $(pure h) $(pure o) $(pure n) $(pure r) $p $a $b |]
+defaultTableConstraint _ = fail "Non TableField Field"
+
+
+mapTypeInstance :: DataDecInfo -> Q Dec
+mapTypeInstance DataDecInfo{dTyName, dTyVars, dConTys} = tySynInstD ''Map (tySynEqn [g, app =<< ff] (app =<< fi))
+  where
+    app = appTTableField dTyName dTyVars dConTys
+
+    f = varT $ mkName "f"
+    g = varT $ mkName "g"
+
+    ff = [t| F $f |]
+    fi = [t| F (IMap $g $f) |]

--- a/src/Opaleye/TypeFamilies.hs
+++ b/src/Opaleye/TypeFamilies.hs
@@ -15,6 +15,8 @@ module Opaleye.TypeFamilies
   , TF.Opt
   , TF.Req
   , TF.Nulls
+  , TH.makeTableAdaptorInstanceMap
   ) where
 
 import Opaleye.Internal.TypeFamilies as TF
+import Opaleye.Internal.TypeFamiliesTH as TH


### PR DESCRIPTION
This adds the ability to have type family style data types easily with some template haskell magic.

This works on data types with a single type argument, and each field uses a TableField type, eg.

```haskell
data UserP f = UserP
    { pName        :: TableField f Name SqlText NN Req
    , pUserEmail   :: TableField f Email SqlText NN Req
    , pEnabled     :: TableField f Bool SqlBool NN Opt
    }
```
You can then call:

```haskell
makeTableAdaptorInstanceMap "pUser" ''UserP
```

and have access to pUser adaptor, the appropriate Default instances, and Map type family instances.