### PR TITLE
added readOnly

### DIFF
--- a/src/Opaleye/Internal/Table.hs
+++ b/src/Opaleye/Internal/Table.hs
@@ -127,6 +127,11 @@ optional columnName = TableProperties
   (optionalW columnName)
   (View (Column (HPQ.BaseTableAttrExpr columnName)))
 
+-- | 'readOnly' is for columns that you must omit on writes, such as
+--  SERIAL columns intended to auto-increment only.
+readOnly :: String -> TableColumns () (Column a)
+readOnly = lmap (const Nothing) . optional
+
 class TableColumn writeType sqlType | writeType -> sqlType where
     -- | Do not use.  Use 'tableField' instead.  Will be deprecated in
     -- 0.7.

--- a/src/Opaleye/Table.hs
+++ b/src/Opaleye/Table.hs
@@ -67,6 +67,7 @@ module Opaleye.Table (-- * Defining tables
                       T.Table,
                       T.tableField,
                       T.optional,
+                      T.readOnly,
                       T.required,
                       -- * Querying tables
                       selectTable,


### PR DESCRIPTION
I often use this `readOnly` definition for SERIAL columns which I only want to auto-increment.

Want to include it in the library?