### PR TITLE
Do not recommend using Opaleye.Constant

### DIFF
--- a/src/Opaleye/SqlTypes.hs
+++ b/src/Opaleye/SqlTypes.hs
@@ -1,6 +1,5 @@
 -- | SQL types and functions to create 'Opaleye.Field.Field_'s of
--- those types.  You may find it more convenient to use
--- "Opaleye.Constant" instead.
+-- those types.
 
 module Opaleye.SqlTypes (module Opaleye.SqlTypes,
                          P.IsSqlType,


### PR DESCRIPTION
The docs for Opaleye.SqlTypes recommended using Opaleye.Constant instead, but the docs for Opaleye.Constant say not to use it. So I'm guessing that leaving this note in was a mistake?