### PR TITLE
Skip the tests that require Postgres by default

### DIFF
--- a/Test/Test.hs
+++ b/Test/Test.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE Arrows              #-}
+{-# LANGUAGE CPP                 #-}
 {-# LANGUAGE FlexibleContexts    #-}
 {-# LANGUAGE OverloadedStrings   #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -1100,7 +1101,17 @@ testLiterals = do
           (\r -> map Time.zonedTimeToUTC r `shouldBe` [Time.zonedTimeToUTC value])
 
 main :: IO ()
-main = do
+#ifdef TEST_WITH_POSTGRES
+main = mainWithPostgres
+#else
+main = mainSkip
+#endif
+
+mainSkip :: IO ()
+mainSkip = putStrLn "Skipping tests that require a running PostgreSQL server; test with the 'test-with-postgres' Cabal flag enabled to run these tests."
+
+mainWithPostgres :: IO ()
+mainWithPostgres = do
   let envVarName = "POSTGRES_CONNSTRING"
 
   connectStringEnvVar <- lookupEnv envVarName

--- a/opaleye.cabal
+++ b/opaleye.cabal
@@ -24,6 +24,11 @@ source-repository head
   type:     git
   location: https://github.com/tomjaguarpaw/haskell-opaleye.git
 
+flag test-with-postgres
+  Description: Run tests that require a running PostgreSQL server
+  Default:     False
+  Manual:      True
+
 library
   default-language: Haskell2010
   hs-source-dirs: src
@@ -129,6 +134,8 @@ test-suite test
     hspec-discover,
     opaleye
   ghc-options: -Wall
+  if flag(test-with-postgres)
+    CPP-Options: -DTEST_WITH_POSTGRES
 
 test-suite tutorial
   default-language: Haskell2010

--- a/stack.yaml
+++ b/stack.yaml
@@ -3,3 +3,6 @@ extra-deps:
 - aeson-1.2.4.0
 - multiset-0.3.4.1
 - base-compat-0.9.3
+flags:
+  opaleye:
+    test-with-postgres: true


### PR DESCRIPTION
I'm running into trouble building Opaleye as a Nix package because the tests fail when there is no running Postgres server, so I was thinking it might be nice if these tests were disabled by default and re-enabled by a flag.