### PR TITLE
Add LeftJoinLateral as a JoinType

### DIFF
--- a/src/Opaleye/Internal/PrimQuery.hs
+++ b/src/Opaleye/Internal/PrimQuery.hs
@@ -18,7 +18,7 @@ data BinOp = Except
            | IntersectAll
              deriving Show
 
-data JoinType = LeftJoin | RightJoin | FullJoin deriving Show
+data JoinType = LeftJoin | RightJoin | FullJoin | LeftJoinLateral deriving Show
 
 data TableIdentifier = TableIdentifier
   { tiSchemaName :: Maybe String

--- a/src/Opaleye/Internal/Print.hs
+++ b/src/Opaleye/Internal/Print.hs
@@ -95,6 +95,7 @@ ppJoinType :: Sql.JoinType -> Doc
 ppJoinType Sql.LeftJoin = text "LEFT OUTER JOIN"
 ppJoinType Sql.RightJoin = text "RIGHT OUTER JOIN"
 ppJoinType Sql.FullJoin = text "FULL OUTER JOIN"
+ppJoinType Sql.LeftJoinLateral = text "LEFT OUTER JOIN LATERAL"
 
 ppAttrs :: Sql.SelectAttrs -> Doc
 ppAttrs Sql.Star                 = text "*"

--- a/src/Opaleye/Internal/Sql.hs
+++ b/src/Opaleye/Internal/Sql.hs
@@ -65,7 +65,7 @@ data Binary = Binary {
   bSelect2 :: Select
 } deriving Show
 
-data JoinType = LeftJoin | RightJoin | FullJoin deriving Show
+data JoinType = LeftJoin | RightJoin | FullJoin | LeftJoinLateral deriving Show
 data BinOp = Except | ExceptAll | Union | UnionAll | Intersect | IntersectAll deriving Show
 
 data Label = Label {
@@ -219,6 +219,7 @@ joinType :: PQ.JoinType -> JoinType
 joinType PQ.LeftJoin = LeftJoin
 joinType PQ.RightJoin = RightJoin
 joinType PQ.FullJoin = FullJoin
+joinType PQ.LeftJoinLateral = LeftJoinLateral
 
 binOp :: PQ.BinOp -> BinOp
 binOp o = case o of


### PR DESCRIPTION
I don't expose this anywhere because I'm actually using Rel8, which only uses opaleye to generate SQL. If you're interested what motivated this however, it's so I can make this combinator:

```haskell
optional :: QueryArr a b -> QueryArr a (MaybeTable b)
optional query = O.QueryArr arrow
  where
    arrow (a, left, tag) = (MaybeTable t' b, join, O.next tag')
      where
        join = O.Join O.LeftJoinLateral true [] bindings left right
        (MaybeTable t b, right, tag') = f (a, O.Unit, tag)
          where
            O.QueryArr f = MaybeTable <$> pure (lit (Just False)) <*> query
        (t', bindings) = O.run (O.runUnpackspec unpackColumns (O.extractAttr "maybe" tag') t)
    true = case lit True of Expr t -> t
```