### PR TITLE
Add InnerJoinLateral as a JoinType

### DIFF
--- a/src/Opaleye/Internal/PrimQuery.hs
+++ b/src/Opaleye/Internal/PrimQuery.hs
@@ -18,7 +18,7 @@ data BinOp = Except
            | IntersectAll
              deriving Show
 
-data JoinType = LeftJoin | RightJoin | FullJoin | LeftJoinLateral deriving Show
+data JoinType = LeftJoin | RightJoin | FullJoin | InnerJoinLateral | LeftJoinLateral deriving Show
 
 data TableIdentifier = TableIdentifier
   { tiSchemaName :: Maybe String

--- a/src/Opaleye/Internal/Print.hs
+++ b/src/Opaleye/Internal/Print.hs
@@ -95,6 +95,7 @@ ppJoinType :: Sql.JoinType -> Doc
 ppJoinType Sql.LeftJoin = text "LEFT OUTER JOIN"
 ppJoinType Sql.RightJoin = text "RIGHT OUTER JOIN"
 ppJoinType Sql.FullJoin = text "FULL OUTER JOIN"
+ppJoinType Sql.InnerJoinLateral = text "INNER JOIN LATERAL"
 ppJoinType Sql.LeftJoinLateral = text "LEFT OUTER JOIN LATERAL"
 
 ppAttrs :: Sql.SelectAttrs -> Doc

--- a/src/Opaleye/Internal/Sql.hs
+++ b/src/Opaleye/Internal/Sql.hs
@@ -65,7 +65,7 @@ data Binary = Binary {
   bSelect2 :: Select
 } deriving Show
 
-data JoinType = LeftJoin | RightJoin | FullJoin | LeftJoinLateral deriving Show
+data JoinType = LeftJoin | RightJoin | FullJoin | InnerJoinLateral | LeftJoinLateral deriving Show
 data BinOp = Except | ExceptAll | Union | UnionAll | Intersect | IntersectAll deriving Show
 
 data Label = Label {
@@ -219,6 +219,7 @@ joinType :: PQ.JoinType -> JoinType
 joinType PQ.LeftJoin = LeftJoin
 joinType PQ.RightJoin = RightJoin
 joinType PQ.FullJoin = FullJoin
+joinType PQ.InnerJoinLateral = InnerJoinLateral
 joinType PQ.LeftJoinLateral = LeftJoinLateral
 
 binOp :: PQ.BinOp -> BinOp


### PR DESCRIPTION
This time my motivation is to able to make the following combinator:

```haskell
laterally :: (Query a -> Query b) -> QueryArr i a -> QueryArr i b
laterally transform as = O.QueryArr go
  where
    go (i, left, tag) = (b, join, tag')
      where
        O.QueryArr f = transform (as . pure i)
        (b, right, tag') = f ((), O.Unit, tag)
        join = O.Join O.InnerJoinLateral true [] [] left right
    true = case lit True of Expr t -> t
```