### PR TITLE
Implement LATERAL subqueries

### DIFF
--- a/opaleye.cabal
+++ b/opaleye.cabal
@@ -56,6 +56,7 @@ library
                    Opaleye.FunctionalJoin,
                    Opaleye.Join,
                    Opaleye.Label,
+                   Opaleye.Lateral,
                    Opaleye.Manipulation,
                    Opaleye.Map,
                    Opaleye.Operators,

--- a/src/Opaleye/Lateral.hs
+++ b/src/Opaleye/Lateral.hs
@@ -1,0 +1,39 @@
+{-# LANGUAGE FlexibleContexts #-}
+
+module Opaleye.Lateral
+  ( lateral
+  , laterally
+  , bilaterally
+  )
+where
+
+import qualified Opaleye.Internal.QueryArr as Q
+import           Opaleye.Select
+
+import           Control.Category ( (<<<) )
+
+
+-- | Implements @LATERAL@ subqueries.
+--
+-- @LATERAL@ gives us goodies like 'Monad' and 'Control.Arrow.ArrowApply'
+-- instances for 'SelectArr'. It also allows us to bypass the scoping rules
+-- of SQL that otherwise restrict operations like
+-- 'Opaleye.Aggregate.aggregate' and 'Opaleye.Binary.union' to 'Select's
+-- rather than 'SelectArr's.
+lateral :: (i -> Select a) -> SelectArr i a
+lateral = Q.lateral
+
+
+-- | Lifts operations like 'Opaleye.Aggregate.aggregate',
+-- 'Opaleye.Order.orderBy' and 'Opaleye.Order.limit', which are restricted to
+-- 'Select' normally, to operate on 'SelectArr's taking arbitrary inputs.
+laterally :: (Select a -> Select b) -> SelectArr i a -> SelectArr i b
+laterally f as = lateral (\i -> f (as <<< pure i))
+
+
+-- | Lifts operations like 'Opaleye.Binary.union', 'Opaleye.Binary.intersect'
+-- and 'Opaleye.Binary.except', which are restricted to 'Select' normally, to
+-- operate on 'SelectArr's taking arbitrary inputs.
+bilaterally :: (Select a -> Select b -> Select c)
+            -> SelectArr i a -> SelectArr i b -> SelectArr i c
+bilaterally f as bs = lateral (\i -> f (as <<< pure i) (bs <<< pure i))


### PR DESCRIPTION
Implement LATERAL subqueries
    
For some context, see the dicussion on #460.
    
I define `lateral` in `Opaleye.Internal.QueryArr` so that we can use it to define `ArrowApply` and `Monad` instances for `QueryArr`.
    
In terms of the grammar, I don't introduce any specific AST constructor for `LATERAL`. Instead, when generating the SQL, we simply always write `FROM LATERAL` instead of `FROM` for subqueries. The advantage of this is that we get a lawful monad instance (`>=> return` is exactly `id` and doesn't pollute the AST). From my testing, this doesn't seem to change the plans that are by Postgres generated for non-lateral queries.
    
I re-export it from `Query.Lateral`, along with `laterally` and `bilaterally`, which also came up in the aforementioned discussion.
    
This would fix #359.