### PR TITLE
Lateral

### DIFF
--- a/opaleye.cabal
+++ b/opaleye.cabal
@@ -56,6 +56,7 @@ library
                    Opaleye.FunctionalJoin,
                    Opaleye.Join,
                    Opaleye.Label,
+                   Opaleye.Lateral,
                    Opaleye.Manipulation,
                    Opaleye.Map,
                    Opaleye.Operators,

--- a/src/Opaleye/Internal/Aggregate.hs
+++ b/src/Opaleye/Internal/Aggregate.hs
@@ -108,7 +108,11 @@ aggregateU agg (c0, primQ, t0) = (c1, primQ', T.next t0)
         projPEs = map fst projPEs_inners
         inners  = map snd projPEs_inners
 
-        primQ' = PQ.Aggregate projPEs inners primQ
+        primQ' = PQ.PQAggregate PQ.Aggregate {
+            PQ.aggregateOperations  = projPEs
+          , PQ.aggregateProjections = inners
+          , PQ.aggregateSubquery    = primQ
+          }
 
 extractAggregateFields
   :: T.Tag

--- a/src/Opaleye/Internal/Optimize.hs
+++ b/src/Opaleye/Internal/Optimize.hs
@@ -39,7 +39,8 @@ removeEmpty = PQ.foldPrimQuery PQ.PrimQueryFold {
   , PQ.baseTable = return .: PQ.BaseTable
   , PQ.product   = \x y -> PQ.Product <$> T.sequence x
                                       <*> pure y
-  , PQ.aggregate = \a i -> fmap (PQ.Aggregate a i)
+  , PQ.aggregate = \aggregate@PQ.Aggregate{ PQ.aggregateSubquery = q } ->
+      fmap (\q' -> PQ.PQAggregate (aggregate { PQ.aggregateSubquery = q' })) q
   , PQ.distinctOnOrderBy = \mDistinctOns -> fmap . PQ.DistinctOnOrderBy mDistinctOns
   , PQ.limit     = fmap . PQ.Limit
   , PQ.join      = \jt pe pes1 pes2 pq1 pq2 -> PQ.Join jt pe pes1 pes2 <$> pq1 <*> pq2

--- a/src/Opaleye/Internal/Optimize.hs
+++ b/src/Opaleye/Internal/Optimize.hs
@@ -39,7 +39,7 @@ removeEmpty = PQ.foldPrimQuery PQ.PrimQueryFold {
   , PQ.baseTable = return .: PQ.BaseTable
   , PQ.product   = \x y -> PQ.Product <$> T.sequence x
                                       <*> pure y
-  , PQ.aggregate = fmap . PQ.Aggregate
+  , PQ.aggregate = \a i -> fmap (PQ.Aggregate a i)
   , PQ.distinctOnOrderBy = \mDistinctOns -> fmap . PQ.DistinctOnOrderBy mDistinctOns
   , PQ.limit     = fmap . PQ.Limit
   , PQ.join      = \jt pe pes1 pes2 pq1 pq2 -> PQ.Join jt pe pes1 pes2 <$> pq1 <*> pq2

--- a/src/Opaleye/Internal/PrimQuery.hs
+++ b/src/Opaleye/Internal/PrimQuery.hs
@@ -46,7 +46,8 @@ data PrimQuery' a = Unit
                   | Aggregate (Bindings (Maybe (HPQ.AggrOp,
                                                 [HPQ.OrderExpr],
                                                 HPQ.AggrDistinct),
-                                          HPQ.PrimExpr))
+                                          HPQ.Symbol))
+                              (Bindings HPQ.PrimExpr)
                               (PrimQuery' a)
                   -- | Represents both @DISTINCT ON@ and @ORDER BY@
                   --   clauses. In order to represent valid SQL only,
@@ -83,7 +84,8 @@ data PrimQueryFold' a p = PrimQueryFold
   , product           :: NEL.NonEmpty p -> [HPQ.PrimExpr] -> p
   , aggregate         :: Bindings (Maybe
                              (HPQ.AggrOp, [HPQ.OrderExpr], HPQ.AggrDistinct),
-                                   HPQ.PrimExpr)
+                                   HPQ.Symbol)
+                      -> Bindings HPQ.PrimExpr
                       -> p
                       -> p
   , distinctOnOrderBy :: Maybe (NEL.NonEmpty HPQ.PrimExpr)
@@ -134,7 +136,7 @@ foldPrimQuery f = fix fold
           Empty a                     -> empty             f a
           BaseTable ti syms           -> baseTable         f ti syms
           Product qs pes              -> product           f (fmap self qs) pes
-          Aggregate aggrs q           -> aggregate         f aggrs (self q)
+          Aggregate aggrs inners q    -> aggregate         f aggrs inners (self q)
           DistinctOnOrderBy dxs oxs q -> distinctOnOrderBy f dxs oxs (self q)
           Limit op q                  -> limit             f op (self q)
           Join j cond pe1 pe2 q1 q2   -> join              f j cond pe1 pe2 (self q1) (self q2)

--- a/src/Opaleye/Internal/QueryArr.hs
+++ b/src/Opaleye/Internal/QueryArr.hs
@@ -76,12 +76,19 @@ instance Arr.ArrowChoice QueryArr where
             Left a -> first3 Left (runQueryArr f (a, primQ, t0))
             Right b -> (Right b, primQ, t0)
 
+instance Arr.ArrowApply QueryArr where
+  app = lateral (\(f, i) -> f <<< pure i)
+
 instance Functor (QueryArr a) where
   fmap f = (arr f <<<)
 
 instance Applicative (QueryArr a) where
   pure = arr . const
   f <*> g = arr (uncurry ($)) <<< (f &&& g)
+
+instance Monad (QueryArr a) where
+  return = pure
+  as >>= f = lateral (\(i, a) -> f a <<< pure i) <<< (id &&& as)
 
 instance P.Profunctor QueryArr where
   dimap f g a = arr g <<< a <<< arr f

--- a/src/Opaleye/Internal/Sql.hs
+++ b/src/Opaleye/Internal/Sql.hs
@@ -124,13 +124,11 @@ product ss pes = SelectFrom $
     newSelect { tables = NEL.toList ss
               , criteria = map sqlExpr pes }
 
-aggregate :: [(Symbol,
-               (Maybe (HPQ.AggrOp, [HPQ.OrderExpr], HPQ.AggrDistinct),
-                Symbol))]
-          -> [(Symbol, HPQ.PrimExpr)]
+aggregate :: PQ.Aggregate Select
           -> Select
-          -> Select
-aggregate aggrs inners s =
+aggregate PQ.Aggregate { PQ.aggregateOperations  = aggrs
+                       , PQ.aggregateProjections = inners
+                       , PQ.aggregateSubquery    = s } =
   SelectFrom $ newSelect {
     attrs = SelectAttrs (ensureColumns (map attr aggrs'))
   , tables = [SelectFrom $ newSelect {

--- a/src/Opaleye/Lateral.hs
+++ b/src/Opaleye/Lateral.hs
@@ -1,9 +1,9 @@
 module Opaleye.Lateral where
 
 import           Opaleye.Select ( Select, SelectArr )
-import           Opaleye.Internal.QueryArr as O
-import           Opaleye.Internal.PrimQuery as O
-import           Opaleye.Internal.HaskellDB.PrimQuery as O
+import qualified Opaleye.Internal.QueryArr as O
+import qualified Opaleye.Internal.PrimQuery as O
+import qualified Opaleye.Internal.HaskellDB.PrimQuery as O
 import           Control.Category ( (<<<) )
 
 
@@ -15,10 +15,10 @@ lateral transform = O.QueryArr qa
   where
     qa (i, primQueryL, tag) = (b, primQueryJoin, tag')
       where
-        (b, primQueryR, tag') = runSimpleQueryArr (transform i) ((), tag)
+        (b, primQueryR, tag') = O.runSimpleQueryArr (transform i) ((), tag)
         primQueryJoin = O.Join O.InnerJoinLateral true [] [] primQueryL primQueryR
 
-    true = O.ConstExpr (BoolLit True)
+    true = O.ConstExpr (O.BoolLit True)
 
 
 -- | Allows to lift operations like 'Opaleye.Aggregate.aggregate',

--- a/src/Opaleye/Lateral.hs
+++ b/src/Opaleye/Lateral.hs
@@ -1,0 +1,37 @@
+module Opaleye.Lateral where
+
+import           Opaleye.Select ( Select, SelectArr )
+import           Opaleye.Internal.QueryArr as O
+import           Opaleye.Internal.PrimQuery as O
+import           Opaleye.Internal.HaskellDB.PrimQuery as O
+import           Control.Category ( (<<<) )
+
+
+-- | Runs a subquery laterally, i.e. using SQL's @LATERAL@.
+--
+-- You might find 'laterally' and 'bilaterally' more convenient to use.
+lateral :: (i -> Select a) -> SelectArr i a
+lateral transform = O.QueryArr qa
+  where
+    qa (i, primQueryL, tag) = (b, primQueryJoin, tag')
+      where
+        (b, primQueryR, tag') = runSimpleQueryArr (transform i) ((), tag)
+        primQueryJoin = O.Join O.InnerJoinLateral true [] [] primQueryL primQueryR
+
+    true = O.ConstExpr (BoolLit True)
+
+
+-- | Allows to lift operations like 'Opaleye.Aggregate.aggregate',
+-- 'Opaleye.Order.orderBy' and 'Opaleye.Order.limit', which are normally
+-- restricted to 'Select', to operate on 'SelectArr's taking arbitrary inputs.
+laterally :: (Select a -> Select b) -> SelectArr i a -> SelectArr i b
+laterally f as = lateral (\i -> f (as <<< pure i))
+
+
+-- | Allows to lift operations like 'Opaleye.Binary.union',
+-- 'Opaleye.Binary.intersect' and 'Opaleye.Binary.except', which are
+-- normally restricted to 'Select', to operate on 'SelectArr's taking
+-- arbitrary inputs.
+bilaterally :: (Select a -> Select b -> Select c)
+            -> SelectArr i a -> SelectArr i b -> SelectArr i c
+bilaterally f as bs = lateral (\i -> f (as <<< pure i) (bs <<< pure i))

--- a/src/Opaleye/Lateral.hs
+++ b/src/Opaleye/Lateral.hs
@@ -11,14 +11,7 @@ import           Control.Category ( (<<<) )
 --
 -- You might find 'laterally' and 'bilaterally' more convenient to use.
 lateral :: (i -> Select a) -> SelectArr i a
-lateral transform = O.QueryArr qa
-  where
-    qa (i, primQueryL, tag) = (b, primQueryJoin, tag')
-      where
-        (b, primQueryR, tag') = O.runSimpleQueryArr (transform i) ((), tag)
-        primQueryJoin = O.Join O.InnerJoinLateral true [] [] primQueryL primQueryR
-
-    true = O.ConstExpr (O.BoolLit True)
+lateral = O.lateral
 
 
 -- | Allows to lift operations like 'Opaleye.Aggregate.aggregate',


### PR DESCRIPTION
Implements a Monad instance for queries, using `LATERAL` joins

(this comes with lateral, which is equivalent to the Monad instance, and laterally and bilaterally which are useful combinators)

I'm more likely to merge this than https://github.com/tomjaguarpaw/haskell-opaleye/pull/465 because the latter makes all joins lateral.  I don't see the point of that at the moment.

Once people start writing monadic queries there's no going back, so I want to be 100% sure this is a sensible thing to do.  I would welcome people testing this.