### PR TITLE
Remove Bindings from Binary and introduce new PrimQuery constructor Rebind

### DIFF
--- a/src/Opaleye/Internal/Binary.hs
+++ b/src/Opaleye/Internal/Binary.hs
@@ -47,7 +47,10 @@ sameTypeBinOpHelper binop binaryspec q1 q2 = Q.simpleQueryArr q where
             PM.run (runBinaryspec binaryspec (extractBinaryFields endTag)
                                     (columns1, columns2))
 
-          newPrimQuery = PQ.Binary binop pes (primQuery1, primQuery2)
+          newPrimQuery = PQ.Binary binop
+            ( PQ.Rebind (map (fmap fst) pes) primQuery1
+            , PQ.Rebind (map (fmap snd) pes) primQuery2
+            )
 
 instance Default Binaryspec (Column a) (Column a) where
   def = binaryspecColumn

--- a/src/Opaleye/Internal/Optimize.hs
+++ b/src/Opaleye/Internal/Optimize.hs
@@ -56,11 +56,12 @@ removeEmpty = PQ.foldPrimQuery PQ.PrimQueryFold {
       PQ.IntersectAll -> binary (const Nothing) (const Nothing) PQ.IntersectAll
   , PQ.label     = fmap . PQ.Label
   , PQ.relExpr   = return .: PQ.RelExpr
+  , PQ.rebind    = fmap . PQ.Rebind
   }
   where -- If only the first argument is Just, do n1 on it
         -- If only the second argument is Just, do n2 on it
-        binary n1 n2 jj exprs = \case
+        binary n1 n2 jj = \case
           (Nothing, Nothing)   -> Nothing
           (Nothing, Just pq2)  -> n2 pq2
           (Just pq1, Nothing)  -> n1 pq1
-          (Just pq1, Just pq2) -> Just (PQ.Binary jj exprs (pq1, pq2))
+          (Just pq1, Just pq2) -> Just (PQ.Binary jj (pq1, pq2))


### PR DESCRIPTION
Basically, Opaleye implements binary operations by rewriting all the columns of both queries to have the same name, before combining. Previously this rewriting of column names was represented in the AST as part of the `Binary` operation itself, whereas now it's a separate step (`Rebind`), and `sameTypeBinOpHelper` (which `unionAll`, `exceptAll` etc are defined in terms of) will do both of these steps at once.

The reason this is necessary is because the `removeEmpty` optimisation, which removes can remove binary operations that are unnecessary (.e.g, `unionAll`ing with `values []`), would generate incorrect queries before because the column names introduced by the binary operation would no longer exist, but the expressions would still refer to them. By making the rebinding and the binary operation itself separate steps, we can safely remove the latter while keeping the former.