### PR TITLE
Implement EXISTS directly

### DIFF
--- a/opaleye.cabal
+++ b/opaleye.cabal
@@ -52,6 +52,7 @@ library
                    Opaleye.Column,
                    Opaleye.Constant,
                    Opaleye.Distinct,
+                   Opaleye.Exists,
                    Opaleye.Field,
                    Opaleye.FunctionalJoin,
                    Opaleye.Join,

--- a/src/Opaleye/Exists.hs
+++ b/src/Opaleye/Exists.hs
@@ -1,0 +1,21 @@
+module Opaleye.Exists (exists) where
+
+import           Opaleye.Field (Field)
+import           Opaleye.Internal.Column (Column (Column))
+import           Opaleye.Internal.QueryArr (runSimpleQueryArr, simpleQueryArr)
+import           Opaleye.Internal.PackMap (run, extractAttr)
+import           Opaleye.Internal.PrimQuery (PrimQuery' (Exists))
+import           Opaleye.Internal.Tag (next)
+import           Opaleye.Select (Select)
+import           Opaleye.SqlTypes (SqlBool)
+
+-- | True if any rows are returned by the given query, false otherwise.
+--
+-- This operation is equivalent to Postgres's @EXISTS@ operator.
+exists :: Select a -> Select (Field SqlBool)
+exists q = simpleQueryArr (f . runSimpleQueryArr q)
+  where
+    f (_, query, tag) = (Column result, Exists binding query, tag')
+      where
+        (result, [(binding, ())]) = run (extractAttr "exists" tag ())
+        tag' = next tag

--- a/src/Opaleye/Internal/Optimize.hs
+++ b/src/Opaleye/Internal/Optimize.hs
@@ -10,7 +10,7 @@ import           Opaleye.Internal.Helpers   ((.:))
 import qualified Data.List.NonEmpty as NEL
 import           Data.Semigroup ((<>))
 
-import           Control.Applicative ((<$>), (<*>), pure)
+import           Control.Applicative ((<$>), (<*>), liftA2, pure)
 import           Control.Arrow (first)
 
 optimize :: PQ.PrimQuery' a -> PQ.PrimQuery' a
@@ -48,7 +48,8 @@ removeEmpty = PQ.foldPrimQuery PQ.PrimQueryFold {
   , PQ.distinctOnOrderBy = \mDistinctOns -> fmap . PQ.DistinctOnOrderBy mDistinctOns
   , PQ.limit     = fmap . PQ.Limit
   , PQ.join      = \jt pe pes1 pes2 pq1 pq2 -> PQ.Join jt pe pes1 pes2 <$> pq1 <*> pq2
-  , PQ.existsf   = \b pq1 pq2 -> PQ.Exists b <$> pq1 <*> pq2
+  , PQ.semijoin  = liftA2 . PQ.Semijoin
+  , PQ.exists    = fmap . PQ.Exists
   , PQ.values    = return .: PQ.Values
   , PQ.binary    = \case
       -- Some unfortunate duplication here

--- a/src/Opaleye/Internal/PrimQuery.hs
+++ b/src/Opaleye/Internal/PrimQuery.hs
@@ -21,6 +21,8 @@ data BinOp = Except
 
 data JoinType = LeftJoin | RightJoin | FullJoin deriving Show
 
+data SemijoinType = Semi | Anti deriving Show
+
 data TableIdentifier = TableIdentifier
   { tiSchemaName :: Maybe String
   , tiTableName  :: String
@@ -76,7 +78,8 @@ data PrimQuery' a = Unit
                               (Bindings HPQ.PrimExpr)
                               (PrimQuery' a)
                               (PrimQuery' a)
-                  | Exists    Bool (PrimQuery' a) (PrimQuery' a)
+                  | Semijoin  SemijoinType (PrimQuery' a) (PrimQuery' a)
+                  | Exists    Symbol (PrimQuery' a)
                   | Values    [Symbol] (NEL.NonEmpty [HPQ.PrimExpr])
                   | Binary    BinOp
                               (PrimQuery' a, PrimQuery' a)
@@ -112,7 +115,8 @@ data PrimQueryFold' a p = PrimQueryFold
                       -> p
                       -> p
                       -> p
-  , existsf           :: Bool -> p -> p -> p
+  , semijoin          :: SemijoinType -> p -> p -> p
+  , exists            :: Symbol -> p -> p
   , values            :: [Symbol] -> NEL.NonEmpty [HPQ.PrimExpr] -> p
   , binary            :: BinOp
                       -> (p, p)
@@ -134,11 +138,12 @@ primQueryFoldDefault = PrimQueryFold
   , distinctOnOrderBy = DistinctOnOrderBy
   , limit             = Limit
   , join              = Join
+  , semijoin          = Semijoin
   , values            = Values
   , binary            = Binary
   , label             = Label
   , relExpr           = RelExpr
-  , existsf           = Exists
+  , exists            = Exists
   , rebind            = Rebind
   }
 
@@ -153,11 +158,12 @@ foldPrimQuery f = fix fold
           DistinctOnOrderBy dxs oxs q -> distinctOnOrderBy f dxs oxs (self q)
           Limit op q                  -> limit             f op (self q)
           Join j cond pe1 pe2 q1 q2   -> join              f j cond pe1 pe2 (self q1) (self q2)
+          Semijoin j q1 q2            -> semijoin          f j (self q1) (self q2)
           Values ss pes               -> values            f ss pes
           Binary binop (q1, q2)       -> binary            f binop (self q1, self q2)
           Label l pq                  -> label             f l (self pq)
           RelExpr pe syms             -> relExpr           f pe syms
-          Exists b q1 q2              -> existsf           f b (self q1) (self q2)
+          Exists s q                  -> exists            f s (self q)
           Rebind star pes q           -> rebind            f star pes (self q)
         fix g = let x = g x in x
 
@@ -166,12 +172,6 @@ times q q' = Product (pure q NEL.:| [pure q']) []
 
 restrict :: HPQ.PrimExpr -> PrimQuery -> PrimQuery
 restrict cond primQ = Product (return (pure primQ)) [cond]
-
-exists :: PrimQuery -> PrimQuery -> PrimQuery
-exists = Exists True
-
-notExists :: PrimQuery -> PrimQuery -> PrimQuery
-notExists = Exists False
 
 isUnit :: PrimQuery' a -> Bool
 isUnit Unit = True

--- a/src/Opaleye/Internal/Print.hs
+++ b/src/Opaleye/Internal/Print.hs
@@ -9,11 +9,12 @@ import           Opaleye.Internal.Sql (Select(SelectFrom,
                                               Table,
                                               RelExpr,
                                               SelectJoin,
+                                              SelectSemijoin,
                                               SelectValues,
                                               SelectBinary,
                                               SelectLabel,
                                               SelectExists),
-                                       From, Join, Values, Binary, Label, Exists)
+                                       From, Join, Semijoin, Values, Binary, Label, Exists)
 
 import qualified Opaleye.Internal.HaskellDB.Sql as HSql
 import qualified Opaleye.Internal.HaskellDB.Sql.Print as HPrint
@@ -27,14 +28,15 @@ import qualified Data.Text          as ST
 type TableAlias = String
 
 ppSql :: Select -> Doc
-ppSql (SelectFrom s)   = ppSelectFrom s
-ppSql (Table table)    = HPrint.ppTable table
-ppSql (RelExpr expr)   = HPrint.ppSqlExpr expr
-ppSql (SelectJoin j)   = ppSelectJoin j
-ppSql (SelectValues v) = ppSelectValues v
-ppSql (SelectBinary v) = ppSelectBinary v
-ppSql (SelectLabel v)  = ppSelectLabel v
-ppSql (SelectExists v) = ppSelectExists v
+ppSql (SelectFrom s)     = ppSelectFrom s
+ppSql (Table table)      = HPrint.ppTable table
+ppSql (RelExpr expr)     = HPrint.ppSqlExpr expr
+ppSql (SelectJoin j)     = ppSelectJoin j
+ppSql (SelectSemijoin j) = ppSelectSemijoin j
+ppSql (SelectValues v)   = ppSelectValues v
+ppSql (SelectBinary v)   = ppSelectBinary v
+ppSql (SelectLabel v)    = ppSelectLabel v
+ppSql (SelectExists v)   = ppSelectExists v
 
 ppDistinctOn :: Maybe (NEL.NonEmpty HSql.SqlExpr) -> Doc
 ppDistinctOn = maybe mempty $ \nel ->
@@ -63,6 +65,16 @@ ppSelectJoin j = text "SELECT *"
                  $$  HPrint.ppSqlExpr (Sql.jCond j)
   where (s1, s2) = Sql.jTables j
 
+ppSelectSemijoin :: Semijoin -> Doc
+ppSelectSemijoin v =
+  text "SELECT *"
+  $$  text "FROM"
+  $$  ppTable (tableAlias 1 (Sql.sjTable v))
+  $$  case Sql.sjType v of
+        Sql.Semi -> text "WHERE EXISTS"
+        Sql.Anti -> text "WHERE NOT EXISTS"
+  $$ parens (ppSql (Sql.sjCriteria v))
+
 ppSelectValues :: Values -> Doc
 ppSelectValues v = text "SELECT"
                    <+> ppAttrs (Sql.vAttrs v)
@@ -86,14 +98,9 @@ ppSelectLabel l = text "/*" <+> text (preprocess (Sql.lLabel l)) <+> text "*/"
                    . ST.pack
 
 ppSelectExists :: Exists -> Doc
-ppSelectExists v =
-  text "SELECT *"
-  $$ text "FROM"
-  $$ ppTable (tableAlias 1 (Sql.existsTable v))
-  $$ case Sql.existsBool v of
-       True -> text "WHERE EXISTS"
-       False -> text "WHERE NOT EXISTS"
-  $$ parens (ppSql (Sql.existsCriteria v))
+ppSelectExists e =
+  text "SELECT EXISTS"
+  <+> ppTable (Sql.sqlSymbol (Sql.existsBinding e), Sql.existsTable e)
 
 ppJoinType :: Sql.JoinType -> Doc
 ppJoinType Sql.LeftJoin = text "LEFT OUTER JOIN"
@@ -131,6 +138,7 @@ ppTable (alias, select) = HPrint.ppAs (Just alias) $ case select of
   RelExpr expr          -> HPrint.ppSqlExpr expr
   SelectFrom selectFrom -> parens (ppSelectFrom selectFrom)
   SelectJoin slj        -> parens (ppSelectJoin slj)
+  SelectSemijoin slj    -> parens (ppSelectSemijoin slj)
   SelectValues slv      -> parens (ppSelectValues slv)
   SelectBinary slb      -> parens (ppSelectBinary slb)
   SelectLabel sll       -> parens (ppSelectLabel sll)

--- a/src/Opaleye/Internal/Sql.hs
+++ b/src/Opaleye/Internal/Sql.hs
@@ -25,6 +25,7 @@ data Select = SelectFrom From
             | RelExpr HSql.SqlExpr
             -- ^ A relation-valued expression
             | SelectJoin Join
+            | SelectSemijoin Semijoin
             | SelectValues Values
             | SelectBinary Binary
             | SelectLabel Label
@@ -56,6 +57,12 @@ data Join = Join {
   }
                 deriving Show
 
+data Semijoin = Semijoin
+  { sjType     :: SemijoinType
+  , sjTable    :: Select
+  , sjCriteria :: Select
+  } deriving Show
+
 data Values = Values {
   vAttrs  :: SelectAttrs,
   vValues :: [[HSql.SqlExpr]]
@@ -68,6 +75,7 @@ data Binary = Binary {
 } deriving Show
 
 data JoinType = LeftJoin | RightJoin | FullJoin deriving Show
+data SemijoinType = Semi | Anti deriving Show
 data BinOp = Except | ExceptAll | Union | UnionAll | Intersect | IntersectAll deriving Show
 data Lateral = Lateral | NonLateral deriving Show
 
@@ -79,9 +87,8 @@ data Label = Label {
 data Returning a = Returning a (NEL.NonEmpty HSql.SqlExpr)
 
 data Exists = Exists
-  { existsBool :: Bool
+  { existsBinding :: Symbol
   , existsTable :: Select
-  , existsCriteria :: Select
   } deriving Show
 
 sqlQueryGenerator :: PQ.PrimQueryFold' V.Void Select
@@ -94,16 +101,17 @@ sqlQueryGenerator = PQ.PrimQueryFold
   , PQ.distinctOnOrderBy = distinctOnOrderBy
   , PQ.limit             = limit_
   , PQ.join              = join
+  , PQ.semijoin          = semijoin
   , PQ.values            = values
   , PQ.binary            = binary
   , PQ.label             = label
   , PQ.relExpr           = relExpr
-  , PQ.existsf           = exists
+  , PQ.exists            = exists
   , PQ.rebind            = rebind
   }
 
-exists :: Bool -> Select -> Select -> Select
-exists b q1 q2 = SelectExists (Exists b q1 q2)
+exists :: Symbol -> Select -> Select
+exists binding table = SelectExists (Exists binding table)
 
 sql :: ([HPQ.PrimExpr], PQ.PrimQuery' V.Void, T.Tag) -> Select
 sql (pes, pq, t) = SelectFrom $ newSelect { attrs = SelectAttrs (ensureColumns (makeAttrs pes))
@@ -223,6 +231,10 @@ join j cond pes1 pes2 s1 s2 =
           , tables = oneTable s
           }
 
+semijoin :: PQ.SemijoinType -> Select -> Select -> Select
+semijoin t q1 q2 = SelectSemijoin (Semijoin (semijoinType t) q1 q2)
+
+
 -- Postgres seems to name columns of VALUES clauses "column1",
 -- "column2", ... . I'm not sure to what extent it is customisable or
 -- how robust it is to rely on this
@@ -243,6 +255,10 @@ joinType :: PQ.JoinType -> JoinType
 joinType PQ.LeftJoin = LeftJoin
 joinType PQ.RightJoin = RightJoin
 joinType PQ.FullJoin = FullJoin
+
+semijoinType :: PQ.SemijoinType -> SemijoinType
+semijoinType PQ.Semi = Semi
+semijoinType PQ.Anti = Anti
 
 binOp :: PQ.BinOp -> BinOp
 binOp o = case o of
@@ -268,9 +284,11 @@ newSelect = From {
 sqlExpr :: HPQ.PrimExpr -> HSql.SqlExpr
 sqlExpr = SG.sqlExpr SD.defaultSqlGenerator
 
+sqlSymbol :: Symbol -> String
+sqlSymbol (Symbol sym t) = T.tagWith t sym
+
 sqlBinding :: (Symbol, HPQ.PrimExpr) -> (HSql.SqlExpr, Maybe HSql.SqlColumn)
-sqlBinding (Symbol sym t, pe) =
-  (sqlExpr pe, Just (HSql.SqlColumn (T.tagWith t sym)))
+sqlBinding (s, pe) = (sqlExpr pe, Just (HSql.SqlColumn (sqlSymbol s)))
 
 ensureColumns :: [(HSql.SqlExpr, Maybe a)]
              -> NEL.NonEmpty (HSql.SqlExpr, Maybe a)

--- a/src/Opaleye/Operators.hs
+++ b/src/Opaleye/Operators.hs
@@ -11,7 +11,8 @@ module Opaleye.Operators (module Opaleye.Operators) where
 import qualified Control.Arrow as A
 import qualified Data.Foldable as F
 import qualified Data.List.NonEmpty as NEL
-
+import           Prelude hiding (not)
+import qualified Opaleye.Exists as E
 import qualified Opaleye.Field as F
 import           Opaleye.Internal.Column (Column(Column), unsafeCase_,
                                           unsafeIfThenElse, unsafeGt)
@@ -25,8 +26,6 @@ import qualified Opaleye.Select   as S
 import qualified Opaleye.SqlTypes as T
 
 import qualified Opaleye.Column   as Column
-import qualified Opaleye.Distinct as Distinct
-import qualified Opaleye.Join     as Join
 
 import qualified Opaleye.Internal.HaskellDB.PrimQuery as HPQ
 
@@ -54,13 +53,13 @@ restrict = QueryArr f where
 {-| Add a @WHERE EXISTS@ clause to the current query. -}
 restrictExists :: S.SelectArr a b -> S.SelectArr a ()
 restrictExists criteria = QueryArr f where
-  f (a, primQ, t0) = ((), PQ.exists primQ existsQ, t1) where
+  f (a, primQ, t0) = ((), PQ.Semijoin PQ.Semi primQ existsQ, t1) where
     (_, existsQ, t1) = runSimpleQueryArr criteria (a, t0)
 
 {-| Add a @WHERE NOT EXISTS@ clause to the current query. -}
 restrictNotExists :: S.SelectArr a b -> S.SelectArr a ()
 restrictNotExists criteria = QueryArr f where
-  f (a, primQ, t0) = ((), PQ.notExists primQ existsQ, t1) where
+  f (a, primQ, t0) = ((), PQ.Semijoin PQ.Anti primQ existsQ, t1) where
     (_, existsQ, t1) = runSimpleQueryArr criteria (a, t0)
 
 {-| Keep only the rows of a query satisfying a given condition, using
@@ -215,32 +214,10 @@ in_ fcas (Column a) = Column $ case NEL.nonEmpty (F.toList fcas) of
 -- | True if the first argument occurs amongst the rows of the second,
 -- false otherwise.
 --
--- This operation is equivalent to Postgres's @IN@ operator but, for
--- expediency, is currently implemented using a @LEFT JOIN@.  Please
--- file a bug if this causes any issues in practice.
+-- This operation is equivalent to Postgres's @IN@ operator.
 inSelect :: D.Default O.EqPP fields fields
          => fields -> S.Select fields -> S.Select (F.Field T.SqlBool)
-inSelect c q = qj'
-  where -- Remove every row that isn't equal to c
-        -- Replace the ones that are with '1'
-        q' = A.arr (const 1)
-             A.<<< keepWhen (c .===)
-             A.<<< q
-
-        -- Left join with a query that has a single row
-        -- We either get a single row with '1'
-        -- or a single row with 'NULL'
-        qj :: Query (F.Field T.SqlInt4, Column (C.Nullable T.SqlInt4))
-        qj = Join.leftJoin (A.arr (const 1))
-                           (Distinct.distinct q')
-                           (uncurry (.==))
-
-        -- Check whether it is 'NULL'
-        qj' :: Query (F.Field T.SqlBool)
-        qj' = A.arr (Opaleye.Operators.not
-                     . Column.isNull
-                     . snd)
-              A.<<< qj
+inSelect c q = E.exists (keepWhen (c .===) A.<<< q)
 
 -- * JSON operators
 


### PR DESCRIPTION
We already have restrictExists and restrictNotExists, which implement `WHERE EXISTS` and `WHERE NOT EXISTS` respectively, however we can't directly use `EXISTS` to get a `Column PGBool`.

My first attempt at this added `exists` and then redefined `restrictExists` and `restrictNotExists` in terms of `laterally exists`. That basically meant that code that originally looked like this:

```sql
SELECT * FROM
  (SELECT "result0_1"
   FROM
   ...) "T1"
WHERE EXISTS (SELECT "result0_1") as "T2"
```

would now become:

```sql
SELECT * FROM
  (SELECT "result0_1"
   FROM
   ...) "T1",
  LATERAL
  (SELECT EXISTS (SELECT foo
                 ) as "exists0_2") "T1"
WHERE "exists0_2"
```

Unfortunately, in a lot of cases, this made Postgres generate a much worse plan than before. So I've preserved the old constructor in `PrimQuery` (but renamed it to `Semijoin`), and repurposed `Exists` to implement just `EXISTS`.

I also reimplmented `inSelect` in terms of this new `exists` operator, to give a demonstration of its utility.