### PR TITLE
Lateral

### DIFF
--- a/opaleye.cabal
+++ b/opaleye.cabal
@@ -78,6 +78,7 @@ library
                    Opaleye.Internal.Helpers,
                    Opaleye.Internal.Join,
                    Opaleye.Internal.Label,
+                   Opaleye.Internal.Lateral,
                    Opaleye.Internal.Manipulation,
                    Opaleye.Internal.Order,
                    Opaleye.Internal.Operators,

--- a/src/Opaleye/Internal/Aggregate.hs
+++ b/src/Opaleye/Internal/Aggregate.hs
@@ -85,21 +85,49 @@ runAggregator
   -> a -> f b
 runAggregator (Aggregator a) = PM.traversePM a
 
+-- In Postgres (and, I believe, standard SQL) "aggregate functions are
+-- not allowed in FROM clause of their own query level".  There
+-- doesn't seem to be any fundamental reason for this, but we are
+-- stuck with it.  That means that in a lateral subquery containing an
+-- aggregation over a field C from a previous subquery we have to
+-- create a new field name for C before we are allowed to aggregate it!
+-- For more information see
+--
+--     https://www.postgresql.org/message-id/20200513110251.GC24083%40cloudinit-builder
+--
+--     https://github.com/tomjaguarpaw/haskell-opaleye/pull/460#issuecomment-626716160
+--
+-- Instead of detecting when we are aggregating over a field from a
+-- previous query we just create new names for all field before we
+-- aggregate.  On the other hand, referring to a field from a previous
+-- query in an ORDER BY expression is totally fine!
 aggregateU :: Aggregator a b
            -> (a, PQ.PrimQuery, T.Tag) -> (b, PQ.PrimQuery, T.Tag)
 aggregateU agg (c0, primQ, t0) = (c1, primQ', T.next t0)
-  where (c1, projPEs) =
+  where (c1, projPEs_inners) =
           PM.run (runAggregator agg (extractAggregateFields t0) c0)
 
-        primQ' = PQ.Aggregate projPEs primQ
+        projPEs = map fst projPEs_inners
+        inners  = map snd projPEs_inners
+
+        primQ' = PQ.Aggregate projPEs (PQ.Rebind True inners primQ)
 
 extractAggregateFields
   :: T.Tag
-  -> (Maybe (HPQ.AggrOp, [HPQ.OrderExpr], HPQ.AggrDistinct), HPQ.PrimExpr)
-  -> PM.PM [(HPQ.Symbol, (Maybe (HPQ.AggrOp, [HPQ.OrderExpr], HPQ.AggrDistinct),
-                          HPQ.PrimExpr))]
+  -> (m, HPQ.PrimExpr)
+  -> PM.PM [((HPQ.Symbol,
+              (m, HPQ.Symbol)),
+              (HPQ.Symbol, HPQ.PrimExpr))]
            HPQ.PrimExpr
-extractAggregateFields = PM.extractAttr "result"
+extractAggregateFields tag (m, pe) = do
+  i <- PM.new
+
+  let souter = HPQ.Symbol ("result" ++ i) tag
+      sinner = HPQ.Symbol ("inner" ++ i) tag
+
+  PM.write ((souter, (m, sinner)), (sinner, pe))
+
+  pure (HPQ.AttrExpr souter)
 
 -- { Boilerplate instances
 

--- a/src/Opaleye/Internal/Binary.hs
+++ b/src/Opaleye/Internal/Binary.hs
@@ -48,8 +48,8 @@ sameTypeBinOpHelper binop binaryspec q1 q2 = Q.simpleQueryArr q where
                                     (columns1, columns2))
 
           newPrimQuery = PQ.Binary binop
-            ( PQ.Rebind (map (fmap fst) pes) primQuery1
-            , PQ.Rebind (map (fmap snd) pes) primQuery2
+            ( PQ.Rebind False (map (fmap fst) pes) primQuery1
+            , PQ.Rebind False (map (fmap snd) pes) primQuery2
             )
 
 instance Default Binaryspec (Column a) (Column a) where

--- a/src/Opaleye/Internal/Lateral.hs
+++ b/src/Opaleye/Internal/Lateral.hs
@@ -1,0 +1,47 @@
+{-# LANGUAGE FlexibleContexts #-}
+
+module Opaleye.Internal.Lateral
+  ( lateral
+  , laterally
+  , bilaterally
+  )
+where
+
+import qualified Opaleye.Internal.QueryArr as Q
+import qualified Opaleye.Internal.PrimQuery as PQ
+import           Opaleye.Select
+
+import           Data.List.NonEmpty ( NonEmpty((:|)) )
+import           Control.Category ( (<<<) )
+
+
+-- | Implements @LATERAL@ subqueries.
+--
+-- @LATERAL@ gives us goodies like 'Monad' and 'Control.Arrow.ArrowApply'
+-- instances for 'SelectArr'. It also allows us to bypass the scoping rules
+-- of SQL that otherwise restrict operations like
+-- 'Opaleye.Aggregate.aggregate' and 'Opaleye.Binary.union' to 'Select's
+-- rather than 'SelectArr's.
+lateral :: (i -> Select a) -> SelectArr i a
+lateral f = Q.QueryArr qa
+  where
+    qa (i, primQueryL, tag) = (a, primQueryJoin, tag')
+      where
+        (a, primQueryR, tag') = Q.runSimpleQueryArr (f i) ((), tag)
+        primQueryJoin = PQ.Product ((PQ.NonLateral, primQueryL)
+                                    :| [(PQ.Lateral, primQueryR)])
+                                   []
+
+-- | Lifts operations like 'Opaleye.Aggregate.aggregate',
+-- 'Opaleye.Order.orderBy' and 'Opaleye.Order.limit', which are restricted to
+-- 'Select' normally, to operate on 'SelectArr's taking arbitrary inputs.
+laterally :: (Select a -> Select b) -> SelectArr i a -> SelectArr i b
+laterally f as = lateral (\i -> f (as <<< pure i))
+
+
+-- | Lifts operations like 'Opaleye.Binary.union', 'Opaleye.Binary.intersect'
+-- and 'Opaleye.Binary.except', which are restricted to 'Select' normally, to
+-- operate on 'SelectArr's taking arbitrary inputs.
+bilaterally :: (Select a -> Select b -> Select c)
+            -> SelectArr i a -> SelectArr i b -> SelectArr i c
+bilaterally f as bs = lateral (\i -> f (as <<< pure i) (bs <<< pure i))

--- a/src/Opaleye/Internal/Optimize.hs
+++ b/src/Opaleye/Internal/Optimize.hs
@@ -56,7 +56,7 @@ removeEmpty = PQ.foldPrimQuery PQ.PrimQueryFold {
       PQ.IntersectAll -> binary (const Nothing) (const Nothing) PQ.IntersectAll
   , PQ.label     = fmap . PQ.Label
   , PQ.relExpr   = return .: PQ.RelExpr
-  , PQ.rebind    = fmap . PQ.Rebind
+  , PQ.rebind    = \b -> fmap . PQ.Rebind b
   }
   where -- If only the first argument is Just, do n1 on it
         -- If only the second argument is Just, do n2 on it

--- a/src/Opaleye/Internal/Optimize.hs
+++ b/src/Opaleye/Internal/Optimize.hs
@@ -18,7 +18,7 @@ optimize = mergeProduct . removeUnit
 
 removeUnit :: PQ.PrimQuery' a -> PQ.PrimQuery' a
 removeUnit = PQ.foldPrimQuery PQ.primQueryFoldDefault { PQ.product   = product }
-  where product pqs pes = PQ.Product pqs' pes
+  where product pqs = PQ.Product pqs'
           where pqs' = case NEL.nonEmpty (NEL.filter (not . PQ.isUnit . snd) pqs) of
                          Nothing -> return (pure PQ.Unit)
                          Just xs -> xs

--- a/src/Opaleye/Internal/Optimize.hs
+++ b/src/Opaleye/Internal/Optimize.hs
@@ -8,9 +8,10 @@ import qualified Opaleye.Internal.PrimQuery as PQ
 import           Opaleye.Internal.Helpers   ((.:))
 
 import qualified Data.List.NonEmpty as NEL
+import           Data.Semigroup ((<>))
 
 import           Control.Applicative ((<$>), (<*>), pure)
-import qualified Data.Traversable    as T
+import           Control.Arrow (first)
 
 optimize :: PQ.PrimQuery' a -> PQ.PrimQuery' a
 optimize = mergeProduct . removeUnit
@@ -18,18 +19,18 @@ optimize = mergeProduct . removeUnit
 removeUnit :: PQ.PrimQuery' a -> PQ.PrimQuery' a
 removeUnit = PQ.foldPrimQuery PQ.primQueryFoldDefault { PQ.product   = product }
   where product pqs pes = PQ.Product pqs' pes
-          where pqs' = case NEL.nonEmpty (NEL.filter (not . PQ.isUnit) pqs) of
-                         Nothing -> return PQ.Unit
+          where pqs' = case NEL.nonEmpty (NEL.filter (not . PQ.isUnit . snd) pqs) of
+                         Nothing -> return (pure PQ.Unit)
                          Just xs -> xs
 
 mergeProduct :: PQ.PrimQuery' a -> PQ.PrimQuery' a
 mergeProduct = PQ.foldPrimQuery PQ.primQueryFoldDefault { PQ.product   = product }
   where product pqs pes = PQ.Product pqs' (pes ++ pes')
           where pqs' = pqs >>= queries
-                queries (PQ.Product qs _) = qs
+                queries (lat, PQ.Product qs _) = fmap (first (lat <>)) qs
                 queries q = return q
                 pes' = NEL.toList pqs >>= conds
-                conds (PQ.Product _ cs) = cs
+                conds (_lat, PQ.Product _ cs) = cs
                 conds _ = []
 
 removeEmpty :: PQ.PrimQuery' a -> Maybe (PQ.PrimQuery' b)
@@ -37,7 +38,11 @@ removeEmpty = PQ.foldPrimQuery PQ.PrimQueryFold {
     PQ.unit      = return PQ.Unit
   , PQ.empty     = const Nothing
   , PQ.baseTable = return .: PQ.BaseTable
-  , PQ.product   = \x y -> PQ.Product <$> T.sequence x
+  , PQ.product   = let sequenceOf l = traverseOf l id
+                       traverseOf = id
+                       _2 = traverse
+                   in
+                   \x y -> PQ.Product <$> sequenceOf (traverse._2) x
                                       <*> pure y
   , PQ.aggregate = fmap . PQ.Aggregate
   , PQ.distinctOnOrderBy = \mDistinctOns -> fmap . PQ.DistinctOnOrderBy mDistinctOns

--- a/src/Opaleye/Internal/PrimQuery.hs
+++ b/src/Opaleye/Internal/PrimQuery.hs
@@ -46,7 +46,7 @@ data PrimQuery' a = Unit
                   | Aggregate (Bindings (Maybe (HPQ.AggrOp,
                                                 [HPQ.OrderExpr],
                                                 HPQ.AggrDistinct),
-                                          HPQ.PrimExpr))
+                                          HPQ.Symbol))
                               (PrimQuery' a)
                   -- | Represents both @DISTINCT ON@ and @ORDER BY@
                   --   clauses. In order to represent valid SQL only,
@@ -85,7 +85,7 @@ data PrimQueryFold' a p = PrimQueryFold
   , product           :: NEL.NonEmpty p -> [HPQ.PrimExpr] -> p
   , aggregate         :: Bindings (Maybe
                              (HPQ.AggrOp, [HPQ.OrderExpr], HPQ.AggrDistinct),
-                                   HPQ.PrimExpr)
+                                   HPQ.Symbol)
                       -> p
                       -> p
   , distinctOnOrderBy :: Maybe (NEL.NonEmpty HPQ.PrimExpr)

--- a/src/Opaleye/Internal/PrimQuery.hs
+++ b/src/Opaleye/Internal/PrimQuery.hs
@@ -70,7 +70,8 @@ data PrimQuery' a = Unit
                               (PrimQuery' a, PrimQuery' a)
                   | Label     String (PrimQuery' a)
                   | RelExpr   HPQ.PrimExpr (Bindings HPQ.PrimExpr)
-                  | Rebind    (Bindings HPQ.PrimExpr)
+                  | Rebind    Bool
+                              (Bindings HPQ.PrimExpr)
                               (PrimQuery' a)
                  deriving Show
 
@@ -107,7 +108,7 @@ data PrimQueryFold' a p = PrimQueryFold
   , label             :: String -> p -> p
   , relExpr           :: HPQ.PrimExpr -> Bindings HPQ.PrimExpr -> p
     -- ^ A relation-valued expression
-  , rebind            :: Bindings HPQ.PrimExpr -> p -> p
+  , rebind            :: Bool -> Bindings HPQ.PrimExpr -> p -> p
   }
 
 
@@ -145,7 +146,7 @@ foldPrimQuery f = fix fold
           Label l pq                  -> label             f l (self pq)
           RelExpr pe syms             -> relExpr           f pe syms
           Exists b q1 q2              -> existsf           f b (self q1) (self q2)
-          Rebind pes q                -> rebind            f pes (self q)
+          Rebind star pes q           -> rebind            f star pes (self q)
         fix g = let x = g x in x
 
 times :: PrimQuery -> PrimQuery -> PrimQuery

--- a/src/Opaleye/Internal/PrimQuery.hs
+++ b/src/Opaleye/Internal/PrimQuery.hs
@@ -154,7 +154,7 @@ foldPrimQuery f = fix fold
           Limit op q                  -> limit             f op (self q)
           Join j cond pe1 pe2 q1 q2   -> join              f j cond pe1 pe2 (self q1) (self q2)
           Values ss pes               -> values            f ss pes
-          Binary binop (q1, q2)   -> binary                f binop (self q1, self q2)
+          Binary binop (q1, q2)       -> binary            f binop (self q1, self q2)
           Label l pq                  -> label             f l (self pq)
           RelExpr pe syms             -> relExpr           f pe syms
           Exists b q1 q2              -> existsf           f b (self q1) (self q2)

--- a/src/Opaleye/Internal/PrimQuery.hs
+++ b/src/Opaleye/Internal/PrimQuery.hs
@@ -3,6 +3,7 @@ module Opaleye.Internal.PrimQuery where
 import           Prelude hiding (product)
 
 import qualified Data.List.NonEmpty as NEL
+import           Data.Semigroup (Semigroup, (<>))
 import qualified Opaleye.Internal.HaskellDB.Sql as HSql
 import qualified Opaleye.Internal.HaskellDB.PrimQuery as HPQ
 import           Opaleye.Internal.HaskellDB.PrimQuery (Symbol)
@@ -18,7 +19,7 @@ data BinOp = Except
            | IntersectAll
              deriving Show
 
-data JoinType = LeftJoin | RightJoin | FullJoin | InnerJoinLateral | LeftJoinLateral deriving Show
+data JoinType = LeftJoin | RightJoin | FullJoin deriving Show
 
 data TableIdentifier = TableIdentifier
   { tiSchemaName :: Maybe String
@@ -31,6 +32,17 @@ tiToSqlTable ti = HSql.SqlTable { HSql.sqlTableSchemaName = tiSchemaName ti
 
 type Bindings a = [(Symbol, a)]
 
+data Lateral = NonLateral | Lateral
+  deriving Show
+
+instance Semigroup Lateral where
+  NonLateral <> NonLateral = NonLateral
+  _ <> _ = Lateral
+
+instance Monoid Lateral where
+  mappend = (<>)
+  mempty = NonLateral
+
 -- We use a 'NEL.NonEmpty' for Product because otherwise we'd have to check
 -- for emptiness explicity in the SQL generation phase.
 
@@ -42,7 +54,7 @@ type Bindings a = [(Symbol, a)]
 data PrimQuery' a = Unit
                   | Empty     a
                   | BaseTable TableIdentifier (Bindings HPQ.PrimExpr)
-                  | Product   (NEL.NonEmpty (PrimQuery' a)) [HPQ.PrimExpr]
+                  | Product   (NEL.NonEmpty (Lateral, PrimQuery' a)) [HPQ.PrimExpr]
                   | Aggregate (Bindings (Maybe (HPQ.AggrOp,
                                                 [HPQ.OrderExpr],
                                                 HPQ.AggrDistinct),
@@ -82,7 +94,7 @@ data PrimQueryFold' a p = PrimQueryFold
   { unit              :: p
   , empty             :: a -> p
   , baseTable         :: TableIdentifier -> Bindings HPQ.PrimExpr -> p
-  , product           :: NEL.NonEmpty p -> [HPQ.PrimExpr] -> p
+  , product           :: NEL.NonEmpty (Lateral, p) -> [HPQ.PrimExpr] -> p
   , aggregate         :: Bindings (Maybe
                              (HPQ.AggrOp, [HPQ.OrderExpr], HPQ.AggrDistinct),
                                    HPQ.Symbol)
@@ -136,7 +148,7 @@ foldPrimQuery f = fix fold
           Unit                        -> unit              f
           Empty a                     -> empty             f a
           BaseTable ti syms           -> baseTable         f ti syms
-          Product qs pes              -> product           f (fmap self qs) pes
+          Product qs pes              -> product           f (fmap (fmap self) qs) pes
           Aggregate aggrs q           -> aggregate         f aggrs (self q)
           DistinctOnOrderBy dxs oxs q -> distinctOnOrderBy f dxs oxs (self q)
           Limit op q                  -> limit             f op (self q)
@@ -150,10 +162,10 @@ foldPrimQuery f = fix fold
         fix g = let x = g x in x
 
 times :: PrimQuery -> PrimQuery -> PrimQuery
-times q q' = Product (q NEL.:| [q']) []
+times q q' = Product (pure q NEL.:| [pure q']) []
 
 restrict :: HPQ.PrimExpr -> PrimQuery -> PrimQuery
-restrict cond primQ = Product (return primQ) [cond]
+restrict cond primQ = Product (return (pure primQ)) [cond]
 
 exists :: PrimQuery -> PrimQuery -> PrimQuery
 exists = Exists True

--- a/src/Opaleye/Internal/Sql.hs
+++ b/src/Opaleye/Internal/Sql.hs
@@ -284,8 +284,11 @@ relExpr pe columns = SelectFrom $
               , tables = [RelExpr (sqlExpr pe)]
               }
 
-rebind :: [(Symbol, HPQ.PrimExpr)] -> Select -> Select
-rebind pes select = SelectFrom newSelect
-  { attrs = SelectAttrs (ensureColumns (map sqlBinding pes))
+rebind :: Bool -> [(Symbol, HPQ.PrimExpr)] -> Select -> Select
+rebind star pes select = SelectFrom newSelect
+  { attrs = selectAttrs (ensureColumns (map sqlBinding pes))
   , tables = [select]
   }
+  where selectAttrs = case star of
+          True  -> SelectAttrsStar
+          False -> SelectAttrs

--- a/src/Opaleye/Internal/Sql.hs
+++ b/src/Opaleye/Internal/Sql.hs
@@ -127,10 +127,10 @@ product ss pes = SelectFrom $
 
 aggregate :: [(Symbol,
                (Maybe (HPQ.AggrOp, [HPQ.OrderExpr], HPQ.AggrDistinct),
-                HPQ.PrimExpr))]
+                HPQ.Symbol))]
           -> Select
           -> Select
-aggregate aggrs s =
+aggregate aggrs' s =
   SelectFrom $ newSelect { attrs = SelectAttrs (ensureColumns (map attr aggrs))
                          , tables = [s]
                          , groupBy = (Just . groupBy') aggrs }
@@ -158,6 +158,8 @@ aggregate aggrs s =
         handleEmpty =
           M.fromMaybe (return (SP.deliteral (HSql.ConstSqlExpr "0")))
           . NEL.nonEmpty
+
+        aggrs = (map . Arr.second . Arr.second) HPQ.AttrExpr aggrs'
 
         groupBy' :: [(symbol, (Maybe aggrOp, HPQ.PrimExpr))]
                  -> NEL.NonEmpty HSql.SqlExpr


### PR DESCRIPTION
Implement lateral subqueries, but don't expose them in the public API yet.

@duairc I'd appreciate it if you would take a look and check it looks sensible to you. I'm minded to merge it ASAP.

Where you had `PrimQuery` and `[(Lateral, PrimQuery)]` I've just used `NonEmpty (Lateral, PrimQuery)`.  The first `Lateral` is indeed redundant but it makes the diff much more understandable if it is present.  I also tidied up some of the SQL generation.


(I'm going to be much happier about merging this if we make it clear that `lateral` is for intrepid adventurers only).