### PR TITLE
Make all queries LATERAL all the time

### DIFF
--- a/src/Opaleye/Internal/PrimQuery.hs
+++ b/src/Opaleye/Internal/PrimQuery.hs
@@ -34,17 +34,6 @@ tiToSqlTable ti = HSql.SqlTable { HSql.sqlTableSchemaName = tiSchemaName ti
 
 type Bindings a = [(Symbol, a)]
 
-data Lateral = NonLateral | Lateral
-  deriving Show
-
-instance Semigroup Lateral where
-  NonLateral <> NonLateral = NonLateral
-  _ <> _ = Lateral
-
-instance Monoid Lateral where
-  mappend = (<>)
-  mempty = NonLateral
-
 -- We use a 'NEL.NonEmpty' for Product because otherwise we'd have to check
 -- for emptiness explicity in the SQL generation phase.
 
@@ -56,9 +45,7 @@ instance Monoid Lateral where
 data PrimQuery' a = Unit
                   | Empty     a
                   | BaseTable TableIdentifier (Bindings HPQ.PrimExpr)
-                  | Product   (NEL.NonEmpty (Lateral, PrimQuery' a)) [HPQ.PrimExpr]
-                  -- | The subqueries to take the product of and the
-                  --   restrictions to apply
+                  | Product   (NEL.NonEmpty (PrimQuery' a)) [HPQ.PrimExpr]
                   | Aggregate (Bindings (Maybe (HPQ.AggrOp,
                                                 [HPQ.OrderExpr],
                                                 HPQ.AggrDistinct),
@@ -104,7 +91,7 @@ data PrimQueryFold' a p = PrimQueryFold
   { unit              :: p
   , empty             :: a -> p
   , baseTable         :: TableIdentifier -> Bindings HPQ.PrimExpr -> p
-  , product           :: NEL.NonEmpty (Lateral, p) -> [HPQ.PrimExpr] -> p
+  , product           :: NEL.NonEmpty p -> [HPQ.PrimExpr] -> p
   , aggregate         :: Bindings (Maybe
                              (HPQ.AggrOp, [HPQ.OrderExpr], HPQ.AggrDistinct),
                                    HPQ.Symbol)
@@ -162,7 +149,7 @@ foldPrimQuery f = fix fold
           Unit                        -> unit              f
           Empty a                     -> empty             f a
           BaseTable ti syms           -> baseTable         f ti syms
-          Product qs pes              -> product           f (fmap (fmap self) qs) pes
+          Product qs pes              -> product           f (fmap self qs) pes
           Aggregate aggrs q           -> aggregate         f aggrs (self q)
           DistinctOnOrderBy dxs oxs q -> distinctOnOrderBy f dxs oxs (self q)
           Limit op q                  -> limit             f op (self q)
@@ -178,10 +165,10 @@ foldPrimQuery f = fix fold
         fix g = let x = g x in x
 
 times :: PrimQuery -> PrimQuery -> PrimQuery
-times q q' = Product (pure q NEL.:| [pure q']) []
+times q q' = Product (q NEL.:| [q']) []
 
 restrict :: HPQ.PrimExpr -> PrimQuery -> PrimQuery
-restrict cond primQ = Product (return (pure primQ)) [cond]
+restrict cond primQ = Product (return primQ) [cond]
 
 isUnit :: PrimQuery' a -> Bool
 isUnit Unit = True

--- a/src/Opaleye/Internal/QueryArr.hs
+++ b/src/Opaleye/Internal/QueryArr.hs
@@ -75,14 +75,7 @@ type Select = SelectArr ()
 -- 'Opaleye.Binary.union', 'Opaleye.Binary.intersect' and
 -- 'Opaleye.Binary.except' to two 'SelectArr's).
 lateral :: (i -> Select a) -> SelectArr i a
-lateral f = QueryArr qa
-  where
-    qa (i, primQueryL, tag) = (a, primQueryJoin, tag')
-      where
-        (a, primQueryR, tag') = runSimpleQueryArr (f i) ((), tag)
-        primQueryJoin = PQ.Product ((PQ.NonLateral, primQueryL)
-                                    :| [(PQ.Lateral, primQueryR)])
-                                   []
+lateral f = QueryArr $ \(i, q, t) -> case f i of QueryArr g -> g ((), q, t)
 
 -- | Convert an arrow argument into a function argument so that it can
 -- be applied inside @do@-notation rather than arrow notation.


### PR DESCRIPTION
[There](https://github.com/tomjaguarpaw/haskell-opaleye/pull/463) [have](https://github.com/tomjaguarpaw/haskell-opaleye/pull/465) [been](https://github.com/tomjaguarpaw/haskell-opaleye/pull/466) [multiple](https://github.com/tomjaguarpaw/haskell-opaleye/pull/470) [attempts](https://github.com/tomjaguarpaw/haskell-opaleye/pull/473) at implementing `LATERAL` in Opaleye. The one that eventually got merged, [this one](https://github.com/tomjaguarpaw/haskell-opaleye/pull/470) is different to the [original implementation](https://github.com/tomjaguarpaw/haskell-opaleye/pull/463) in that the original made all joins `LATERAL` indiscriminately (and thus the actual `lateral` combinator was a no-op that just opened up the `QueryArr` type), whereas the new one will only add `LATERAL` to queries when you specifically ask it to.

In the original implementation, [`optional`](https://hackage.haskell.org/package/opaleye-0.7.0.0/docs/Opaleye-MaybeFields.html#v:optional), the underlying `LEFT JOIN` is implemented as `LEFT JOIN LATERAL`, wheras the in new implementation, the left join is implemented as a non-lateral `LEFT JOIN`, with the laterality being added one level up. On the vast majority of queries this performs exactly the same, but there are some pathological cases where this is a regression, unfortunately. In our codebase we have observed some queries that are two orders of magnitude slower now, and several more by one order of magnitude.

I also apologise for not speaking up about this before you released Opaleye 0.7.0.0 — we were vaguely aware that this was causing us problems, but we were focused elsewhere at the time and we also didn't understand the full extent of it until we we ported the remaining uses of `leftJoinA` over to `optional` in our codebase.

I also appreciate that you're reluctant to make everything `LATERAL` and thus you're unlikely to merge this as is. But it's still want to post this to document the problem, bring the solution up to date against the latest `master` and to start/continue the discussion.