### PR TITLE
Fix stack.yaml, cabal.project

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,1 +1,3 @@
-packages: opaleye.cabal
+packages:
+  opaleye.cabal
+  opaleye-sqlite/opaleye-sqlite.cabal

--- a/cabal.project
+++ b/cabal.project
@@ -1,3 +1,2 @@
 packages:
   opaleye.cabal
-  opaleye-sqlite/opaleye-sqlite.cabal

--- a/opaleye-sqlite/opaleye-sqlite.cabal
+++ b/opaleye-sqlite/opaleye-sqlite.cabal
@@ -36,8 +36,8 @@ library
     , direct-sqlite       >= 2.3.13  && < 2.4
     , pretty              >= 1.1.1.0 && < 1.2
     , product-profunctors >= 0.6.2   && < 0.12
-    , profunctors         >= 4.0     && < 5.3
-    , semigroups          >= 0.13    && < 0.19
+    , profunctors         >= 4.0     && < 5.6
+    , semigroups          >= 0.13    && < 0.20
     , sqlite-simple
     , text                >= 0.11    && < 1.3
     , transformers        >= 0.3     && < 0.6

--- a/opaleye-sqlite/stack.yaml
+++ b/opaleye-sqlite/stack.yaml
@@ -1,0 +1,4 @@
+resolver: lts-16.29
+extra-deps:
+- direct-sqlite-2.3.26
+- sqlite-simple-0.4.18.0

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,7 +1,1 @@
 resolver: lts-16.29
-packages:
-- .
-- opaleye-sqlite
-extra-deps:
-- direct-sqlite-2.3.26
-- sqlite-simple-0.4.18.0

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,7 @@
 resolver: lts-12.1
+packages:
+- .
+- opaleye-sqlite
 extra-deps:
 - aeson-1.2.4.0
 - multiset-0.3.4.1

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,8 +1,7 @@
-resolver: lts-12.1
+resolver: lts-16.29
 packages:
 - .
 - opaleye-sqlite
 extra-deps:
-- aeson-1.2.4.0
-- multiset-0.3.4.1
-- base-compat-0.9.3
+- direct-sqlite-2.3.26
+- sqlite-simple-0.4.18.0


### PR DESCRIPTION
- the sqlite sub-package was not built, I added the `packages` stanza in stack.yaml and cabal.project.
- resolver and dependencies were outdated and caused the build to fail.  moving to latest lts and playing with the version bounds a litlte more fixed that.
