### PR TITLE
Implement EXISTS directly

### DIFF
--- a/Test/QuickCheck.hs
+++ b/Test/QuickCheck.hs
@@ -17,6 +17,7 @@ import           Opaleye.Test.TraverseA (traverseA1)
 
 import qualified Opaleye as O
 import qualified Opaleye.Join as OJ
+import qualified Opaleye.Exists as OE
 
 import qualified Database.PostgreSQL.Simple as PGS
 import           Control.Applicative (Applicative, pure, (<$>), (<*>))
@@ -499,6 +500,14 @@ lateral (ArbitraryKleisli f) =
   compareDenotation (O.lateral f) (lateralDenotation (denotation . f'))
   where f' = f . fieldsOfHaskells
 
+exists :: ArbitrarySelect -> Connection -> IO TQ.Property
+exists = compareDenotationNoSort' (existsQ OE.exists) (existsQ existsList)
+  where existsList l = [not (null l)]
+        existsQ existsf q = do
+          exists_ <- existsf q
+          pure (Choices [Left (CBool exists_)])
+
+
 {- TODO
 
   * Nullability
@@ -572,6 +581,7 @@ run conn = do
   test1 maybeFieldsToSelect
   test2 traverseMaybeFields
   test2 lateral
+  test1 exists
 
 -- }
 

--- a/opaleye.cabal
+++ b/opaleye.cabal
@@ -53,6 +53,7 @@ library
                    Opaleye.Constant,
                    Opaleye.Distinct,
                    Opaleye.Experimental.Enum,
+                   Opaleye.Exists,
                    Opaleye.Field,
                    Opaleye.FunctionalJoin,
                    Opaleye.Join,

--- a/src/Opaleye/Exists.hs
+++ b/src/Opaleye/Exists.hs
@@ -1,0 +1,21 @@
+module Opaleye.Exists (exists) where
+
+import           Opaleye.Field (Field)
+import           Opaleye.Internal.Column (Column (Column))
+import           Opaleye.Internal.QueryArr (runSimpleQueryArr, simpleQueryArr)
+import           Opaleye.Internal.PackMap (run, extractAttr)
+import           Opaleye.Internal.PrimQuery (PrimQuery' (Exists))
+import           Opaleye.Internal.Tag (next)
+import           Opaleye.Select (Select)
+import           Opaleye.SqlTypes (SqlBool)
+
+-- | True if any rows are returned by the given query, false otherwise.
+--
+-- This operation is equivalent to Postgres's @EXISTS@ operator.
+exists :: Select a -> Select (Field SqlBool)
+exists q = simpleQueryArr (f . runSimpleQueryArr q)
+  where
+    f (_, query, tag) = (Column result, Exists binding query, tag')
+      where
+        (result, [(binding, ())]) = run (extractAttr "exists" tag ())
+        tag' = next tag

--- a/src/Opaleye/Internal/Optimize.hs
+++ b/src/Opaleye/Internal/Optimize.hs
@@ -10,7 +10,7 @@ import           Opaleye.Internal.Helpers   ((.:))
 import qualified Data.List.NonEmpty as NEL
 import           Data.Semigroup ((<>))
 
-import           Control.Applicative ((<$>), (<*>), pure)
+import           Control.Applicative ((<$>), (<*>), liftA2, pure)
 import           Control.Arrow (first)
 
 optimize :: PQ.PrimQuery' a -> PQ.PrimQuery' a
@@ -48,7 +48,8 @@ removeEmpty = PQ.foldPrimQuery PQ.PrimQueryFold {
   , PQ.distinctOnOrderBy = \mDistinctOns -> fmap . PQ.DistinctOnOrderBy mDistinctOns
   , PQ.limit     = fmap . PQ.Limit
   , PQ.join      = \jt pe pes1 pes2 pq1 pq2 -> PQ.Join jt pe pes1 pes2 <$> pq1 <*> pq2
-  , PQ.existsf   = \b pq1 pq2 -> PQ.Exists b <$> pq1 <*> pq2
+  , PQ.semijoin  = liftA2 . PQ.Semijoin
+  , PQ.exists    = fmap . PQ.Exists
   , PQ.values    = return .: PQ.Values
   , PQ.binary    = \case
       -- Some unfortunate duplication here


### PR DESCRIPTION
We already have restrictExists and restrictNotExists, which implement `WHERE EXISTS` and `WHERE NOT EXISTS` respectively, however we can't directly use `EXISTS` to get a `Column PGBool`.

My first attempt at this added `exists` and then redefined `restrictExists` and `restrictNotExists` in terms of `laterally exists`. That basically meant that code that originally looked like this:

```sql
SELECT * FROM
  (SELECT "result0_1"
   FROM
   ...) "T1"
WHERE EXISTS (SELECT "result0_1") as "T2"
```

would now become:

```sql
SELECT * FROM
  (SELECT "result0_1"
   FROM
   ...) "T1",
  LATERAL
  (SELECT EXISTS (SELECT foo
                 ) as "exists0_2") "T1"
WHERE "exists0_2"
```

Unfortunately, in a lot of cases, this made Postgres generate a much worse plan than before. So I've preserved the old constructor in `PrimQuery` (but renamed it to `Semijoin`), and repurposed `Exists` to implement just `EXISTS`.

I also reimplmented `inSelect` in terms of this new `exists` operator, to give a demonstration of its utility.