### PR TITLE
Add support for json_agg aggregate function and json_build_object

### DIFF
--- a/Test/Test.hs
+++ b/Test/Test.hs
@@ -155,14 +155,6 @@ table3Q = O.selectTable table3
 table6Q :: Select (Field O.SqlText, Field O.SqlText)
 table6Q = O.selectTable table6
 
-table6Json :: SelectArr () (O.Column O.SqlJson)
-table6Json = do
-  (firstCol, secondCol) <- O.selectTable table6
-  return
-    . JS.jsonBuildObject
-    $ JS.jsonBuildObjectField "summary" firstCol
-      <> JS.jsonBuildObjectField "details" secondCol
-
 table7Q :: Select (Field O.SqlText, Field O.SqlText)
 table7Q = O.selectTable table7
 
@@ -547,7 +539,12 @@ testStringJsonAggregate =
       )
   where
     r = Json.decode "[{\"summary\": \"xy\", \"details\": \"a\"}, {\"summary\": \"z\", \"details\": \"a\"}, {\"summary\": \"more text\", \"details\": \"a\"}]"
-    q = O.aggregate O.jsonAgg table6Json
+    q = O.aggregate O.jsonAgg $ do
+      (firstCol, secondCol) <- O.selectTable table6
+      return
+        . JS.jsonBuildObject
+        $ JS.jsonBuildObjectField "summary" firstCol
+          <> JS.jsonBuildObjectField "details" secondCol
 
 testStringAggregate :: Test
 testStringAggregate = it "" $ q `selectShouldReturnSorted` expected

--- a/opaleye.cabal
+++ b/opaleye.cabal
@@ -147,10 +147,7 @@ test-suite test
     hspec,
     hspec-discover,
     opaleye
-  ghc-options: 
-    -Wall
-    -fwrite-ide-info
-    -hiedir=.hie
+  ghc-options: -Wall
 
 test-suite tutorial
   default-language: Haskell2010

--- a/opaleye.cabal
+++ b/opaleye.cabal
@@ -84,6 +84,7 @@ library
                    Opaleye.Internal.Helpers,
                    Opaleye.Internal.Inferrable,
                    Opaleye.Internal.Join,
+                   Opaleye.Internal.JSONBuildObjectFields,
                    Opaleye.Internal.Label,
                    Opaleye.Internal.Lateral,
                    Opaleye.Internal.Map,
@@ -146,7 +147,10 @@ test-suite test
     hspec,
     hspec-discover,
     opaleye
-  ghc-options: -Wall
+  ghc-options: 
+    -Wall
+    -fwrite-ide-info
+    -hiedir=.hie
 
 test-suite tutorial
   default-language: Haskell2010

--- a/src/Opaleye/Aggregate.hs
+++ b/src/Opaleye/Aggregate.hs
@@ -143,7 +143,7 @@ boolAnd = A.makeAggr HPQ.AggrBoolAnd
 arrayAgg :: Aggregator (C.Column a) (C.Column (T.SqlArray a))
 arrayAgg = A.makeAggr HPQ.AggrArr
 
-jsonAgg :: Aggregator (C.Column a) (C.Column T.SqlJson)
+jsonAgg :: Aggregator (C.Column a) (C.Column (C.Nullable T.SqlJson))
 jsonAgg = A.makeAggr HPQ.JsonArr
 
 stringAgg :: C.Column T.SqlText

--- a/src/Opaleye/Aggregate.hs
+++ b/src/Opaleye/Aggregate.hs
@@ -143,7 +143,7 @@ boolAnd = A.makeAggr HPQ.AggrBoolAnd
 arrayAgg :: Aggregator (C.Column a) (C.Column (T.SqlArray a))
 arrayAgg = A.makeAggr HPQ.AggrArr
 
-jsonAgg :: Aggregator (C.Column a) (C.Column (C.Nullable T.SqlJson))
+jsonAgg :: Aggregator (C.Column a) (C.Column T.SqlJson)
 jsonAgg = A.makeAggr HPQ.JsonArr
 
 stringAgg :: C.Column T.SqlText

--- a/src/Opaleye/Aggregate.hs
+++ b/src/Opaleye/Aggregate.hs
@@ -25,6 +25,7 @@ module Opaleye.Aggregate
        , boolOr
        , boolAnd
        , arrayAgg
+       , jsonAgg
        , stringAgg
        -- * Counting rows
        , countRows
@@ -142,6 +143,9 @@ boolAnd = A.makeAggr HPQ.AggrBoolAnd
 
 arrayAgg :: Aggregator (C.Column a) (C.Column (T.SqlArray a))
 arrayAgg = A.makeAggr HPQ.AggrArr
+
+jsonAgg :: Aggregator (C.Column a) (C.Column (T.SqlArray a))
+jsonAgg = A.makeAggr HPQ.JsonArr
 
 stringAgg :: C.Column T.SqlText
           -> Aggregator (C.Column T.SqlText) (C.Column T.SqlText)

--- a/src/Opaleye/Aggregate.hs
+++ b/src/Opaleye/Aggregate.hs
@@ -144,7 +144,7 @@ boolAnd = A.makeAggr HPQ.AggrBoolAnd
 arrayAgg :: Aggregator (C.Column a) (C.Column (T.SqlArray a))
 arrayAgg = A.makeAggr HPQ.AggrArr
 
-jsonAgg :: Aggregator (C.Column a) (C.Column (T.SqlArray a))
+jsonAgg :: Aggregator (C.Column a) (C.Column T.SqlJson)
 jsonAgg = A.makeAggr HPQ.JsonArr
 
 stringAgg :: C.Column T.SqlText

--- a/src/Opaleye/Internal/HaskellDB/PrimQuery.hs
+++ b/src/Opaleye/Internal/HaskellDB/PrimQuery.hs
@@ -78,7 +78,7 @@ data UnOp = OpNot
 
 data AggrOp     = AggrCount | AggrSum | AggrAvg | AggrMin | AggrMax
                 | AggrStdDev | AggrStdDevP | AggrVar | AggrVarP
-                | AggrBoolOr | AggrBoolAnd | AggrArr | JsonArr 
+                | AggrBoolOr | AggrBoolAnd | AggrArr | JsonArr
                 | AggrStringAggr PrimExpr
                 | AggrOther String
                 deriving (Show,Read)

--- a/src/Opaleye/Internal/HaskellDB/PrimQuery.hs
+++ b/src/Opaleye/Internal/HaskellDB/PrimQuery.hs
@@ -78,7 +78,8 @@ data UnOp = OpNot
 
 data AggrOp     = AggrCount | AggrSum | AggrAvg | AggrMin | AggrMax
                 | AggrStdDev | AggrStdDevP | AggrVar | AggrVarP
-                | AggrBoolOr | AggrBoolAnd | AggrArr | AggrStringAggr PrimExpr
+                | AggrBoolOr | AggrBoolAnd | AggrArr | JsonArr 
+                | AggrStringAggr PrimExpr
                 | AggrOther String
                 deriving (Show,Read)
 

--- a/src/Opaleye/Internal/HaskellDB/Sql/Default.hs
+++ b/src/Opaleye/Internal/HaskellDB/Sql/Default.hs
@@ -227,6 +227,7 @@ showAggrOp AggrVarP           = "VarP"
 showAggrOp AggrBoolAnd        = "BOOL_AND"
 showAggrOp AggrBoolOr         = "BOOL_OR"
 showAggrOp AggrArr            = "ARRAY_AGG"
+showAggrOp JsonArr            = "JSON_AGG"
 showAggrOp (AggrStringAggr _) = "STRING_AGG"
 showAggrOp (AggrOther s)      = s
 

--- a/src/Opaleye/Internal/JSONBuildObjectFields.hs
+++ b/src/Opaleye/Internal/JSONBuildObjectFields.hs
@@ -2,6 +2,7 @@ module Opaleye.Internal.JSONBuildObjectFields
   ( JSONBuildObjectFields,
     jsonBuildObjectField,
     jsonBuildObject,
+    jsonCoalesce
   )
 where
 
@@ -29,3 +30,6 @@ jsonBuildObject (JSONBuildObjectFields jbofs) = Column $ FunExpr "json_build_obj
   where
     args = concatMap mapLabelsToPrimExpr jbofs
     mapLabelsToPrimExpr (label, expr) = [ConstExpr $ StringLit label, expr]
+
+jsonCoalesce :: Column a -> Column SqlJson
+jsonCoalesce (Column v) = Column $ FunExpr "COALESCE" [v, ConstExpr $ StringLit "[]"]

--- a/src/Opaleye/Internal/JSONBuildObjectFields.hs
+++ b/src/Opaleye/Internal/JSONBuildObjectFields.hs
@@ -1,0 +1,31 @@
+module Opaleye.Internal.JSONBuildObjectFields
+  ( JSONBuildObjectFields,
+    jsonBuildObjectField,
+    jsonBuildObject,
+  )
+where
+
+import Opaleye.Internal.Column (Column (Column))
+import Opaleye.Internal.HaskellDB.PrimQuery (Literal (StringLit), PrimExpr (ConstExpr, FunExpr))
+import Opaleye.Internal.PGTypesExternal (SqlJson)
+
+newtype JSONBuildObjectFields
+  = JSONBuildObjectFields [(String, PrimExpr)]
+
+instance Semigroup JSONBuildObjectFields where
+  (<>)
+    (JSONBuildObjectFields a)
+    (JSONBuildObjectFields b) =
+      JSONBuildObjectFields $ a <> b
+
+instance Monoid JSONBuildObjectFields where
+  mempty = JSONBuildObjectFields mempty
+
+jsonBuildObjectField :: String -> Column a -> JSONBuildObjectFields
+jsonBuildObjectField f (Column v) = JSONBuildObjectFields [(f, v)]
+
+jsonBuildObject :: JSONBuildObjectFields -> Column SqlJson
+jsonBuildObject (JSONBuildObjectFields jbofs) = Column $ FunExpr "json_build_object" args
+  where
+    args = concatMap mapLabelsToPrimExpr jbofs
+    mapLabelsToPrimExpr (label, expr) = [ConstExpr $ StringLit label, expr]


### PR DESCRIPTION
This PR adds support for the `json_agg` aggregate function, and the `json_build_object` function.

This enables construction of a query that returns it's result as a JSON array bytestring. This can significantly increase throughput since you don't need to query, fetch, parse into records, then serialize into JSON.

```haskell
q = O.aggregate O.jsonAgg $ do
      (firstCol, secondCol) <- O.selectTable table1
      (firstCol2, secondCol2) <- O.selectTable table2
      O.viaLateral O.restrict (firstCol .== firstCol2)
      let blog_post =
            JS.jsonBuildObject $
              JS.jsonBuildObjectField "summary" firstCol2
                <> JS.jsonBuildObjectField "details" secondCol2
      return
        . JS.jsonBuildObject
        $ JS.jsonBuildObjectField "id" firstCol
          <> JS.jsonBuildObjectField "name" secondCol
          <> JS.jsonBuildObjectField "blog_post" blog_post
```
generates this SQL:
```sql
SELECT
"result0_3" as "result1_4"
FROM (SELECT
      *
      FROM (SELECT
            JSON_AGG("inner0_3") as "result0_3"
            FROM (SELECT
                  json_build_object(E'id',"column10_1",E'name',"column21_1",E'blog_post',json_build_object(E'summary',"column10_2",E'details',"column21_2")) as "inner0_3",
                  *
                  FROM (SELECT
                        *
                        FROM (SELECT
                              "column1" as "column10_1",
                              "column2" as "column21_1"
                              FROM "table1" as "T1") as "T1",
                             LATERAL
                             (SELECT
                              "column1" as "column10_2",
                              "column2" as "column21_2"
                              FROM "TABLE2" as "T1") as "T2",
                             LATERAL
                             (SELECT
                              0) as "T3"
                        WHERE (("column10_1") = ("column10_2"))) as "T1") as "T1"
            GROUP BY COALESCE(0)) as "T1") as "T1"
```
which returns this JSON:
```json
[{"id" : 1, "name" : 100, "blog_post" : {"summary" : 1, "details" : 100}}, {"id" : 1, "name" : 100, "blog_post" : {"summary" : 1, "details" : 100}}, {"id" : 1, "name" : 200, "blog_post" : {"summary" : 1, "details" : 100}}]
```