### PR TITLE
Authorize @ocharles to take ownership of package

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,13 +101,14 @@ Agile](http://www.purelyagile.com/).
 
 # Backup maintainers
 
-In the event of the main developer becoming unreachable, please
-contact the following who are authorised to make bugfixes and
-dependency version bumps:
+The only person authorised to merge to `master` or upload this package
+to Hackage is Tom Ellis.
 
-* Adam Bergmark
-* Erik Hesselink
-* Oliver Charles
+However, to ensure continuity of service to Opaleye users, if Tom
+Ellis is unavailable or unresponsive to maintenance requests for three
+months then full ownership of the project, including the GitHub
+repository, Hackage upload rights, and the right to amend this backup
+maintainers policy, passes to Oliver Charles (ollie@ocharles.org.uk).
 
 # Contributors
 


### PR DESCRIPTION
I'm becoming increasingly concerned by stories of various packages in the ecosystem becoming maintainerless. To reduce the risk of this happening to Opaleye I wish to make the following "living will". 

@ocharles, would you be willing to become my first [legatee](https://en.wiktionary.org/wiki/legatee)? I would give you full access to this repository and Hackage upload rights in expectation that you would only use them if I become unavailable. If that occurs you are welcome to do with the package what you think is best.

Subsequently I will also see if Shane, Erik and Adam would be willing to serve in a similar capacity.