### PR TITLE
Add optionalInternal

### DIFF
--- a/src/Opaleye/Internal/MaybeFields.hs
+++ b/src/Opaleye/Internal/MaybeFields.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE ViewPatterns #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE Arrows #-}
@@ -133,8 +134,8 @@ optional = Opaleye.Internal.Lateral.laterally optionalSelect
 
     go query ((), tag) = (MaybeFields present a, join, Tag.next tag')
       where
-        (MaybeFields t a, right, tag') =
-          IQ.runSimpleQueryArr (justFields <$> query) ((), tag)
+        (justFields->MaybeFields t a, right, tag') =
+          IQ.runSimpleQueryArr query ((), tag)
 
         present = isNotNull (IC.unsafeCoerceColumn t')
 

--- a/src/Opaleye/Internal/MaybeFields.hs
+++ b/src/Opaleye/Internal/MaybeFields.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE ViewPatterns #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE Arrows #-}
@@ -134,7 +133,7 @@ optional = Opaleye.Internal.Lateral.laterally optionalSelect
 
     go query ((), tag) = (MaybeFields present a, join, Tag.next tag')
       where
-        (justFields->MaybeFields _ a, right, tag') =
+        (a, right, tag') =
           IQ.runSimpleQueryArr query ((), tag)
 
         present = isNotNull (IC.unsafeCoerceColumn t')

--- a/src/Opaleye/Internal/MaybeFields.hs
+++ b/src/Opaleye/Internal/MaybeFields.hs
@@ -134,13 +134,13 @@ optional = Opaleye.Internal.Lateral.laterally optionalSelect
 
     go query ((), tag) = (MaybeFields present a, join, Tag.next tag')
       where
-        (justFields->MaybeFields t a, right, tag') =
+        (justFields->MaybeFields _ a, right, tag') =
           IQ.runSimpleQueryArr query ((), tag)
 
         present = isNotNull (IC.unsafeCoerceColumn t')
 
         (t', bindings) =
-          PM.run (U.runUnpackspec U.unpackspecField (PM.extractAttr "maybe" tag') t)
+          PM.run (U.runUnpackspec U.unpackspecField (PM.extractAttr "maybe" tag') (Opaleye.SqlTypes.sqlBool True))
         join lat left = PQ.Join PQ.LeftJoin true (PQ.NonLateral, left) (lat, (PQ.Rebind True bindings right))
     true = HPQ.ConstExpr (HPQ.BoolLit True)
     isNotNull = Opaleye.Internal.Operators.not . Opaleye.Field.isNull


### PR DESCRIPTION
In the hope of avoiding drift between Opaleye and Rel8 I'd like to offer a generic version of `optional` called `optionalInternal` which should be sufficient to replace your `optional` with.  I suspect it would be

```haskell
optional = optionalInternal (MaybeTable . fromExpr)
```

[EDIT: Oh, it's not quite that because you'd have to hit it with `Column a -> Expr b`.]

Is that something you would take advantage of? If so then I will merge this and put it in the same release as the LATERAL stuff.

cc @duairc 