### PR TITLE
distinctOn an empty set of columns should be `limit 1`, not a no-op

### DIFF
--- a/src/Opaleye/Internal/Order.hs
+++ b/src/Opaleye/Internal/Order.hs
@@ -76,6 +76,14 @@ distinctOnBy ups proj ord (cols, pq, t) = (cols, pqOut, t)
             x:xs -> PQ.DistinctOnOrderBy (Just $ x NL.:| xs) (orderExprs cols ord) pq
             []   -> pq
 
+distinctOnByCorrect :: U.Unpackspec b b -> (a -> b) -> Order a
+             -> (a, PQ.PrimQuery, T.Tag) -> (a, PQ.PrimQuery, T.Tag)
+distinctOnByCorrect ups proj ord (cols, pq, t) = (cols, pqOut, t)
+    where pqOut = case U.collectPEs ups (proj cols) of
+            x:xs -> PQ.DistinctOnOrderBy (Just $ x NL.:| xs) oexprs pq
+            []   -> PQ.Limit (PQ.LimitOp 1) (PQ.DistinctOnOrderBy Nothing oexprs pq)
+          oexprs = orderExprs cols ord
+
 -- | Order the results of a given query exactly, as determined by the given list
 -- of input columns. Note that this list does not have to contain an entry for
 -- every result in your query: you may exactly order only a subset of results,


### PR DESCRIPTION
I understand why this is made a no-op, because an empty list of columns in a `DISTINCT ON` query is not syntactically valid in SQL. However, our Haskell types don't forbid it. So the question is, semantically, what does this mean? And I think it has to be an unconditional `limit 1`.