### PR TITLE
Add support for interval types and + and - operations

### DIFF
--- a/opaleye.cabal
+++ b/opaleye.cabal
@@ -41,7 +41,7 @@ library
     , semigroups          >= 0.13    && < 0.20
     , text                >= 0.11    && < 1.3
     , transformers        >= 0.3     && < 0.6
-    , time                >= 1.4     && < 1.10
+    , time-compat         >= 1.9.5   && < 1.12
     , time-locale-compat  >= 0.1     && < 0.2
     , uuid                >= 1.3     && < 1.4
     , void                >= 0.4     && < 0.8
@@ -141,7 +141,7 @@ test-suite test
     QuickCheck,
     semigroups,
     text >= 0.11 && < 1.3,
-    time,
+    time-compat,
     uuid,
     transformers,
     hspec,

--- a/src/Opaleye/Internal/Constant.hs
+++ b/src/Opaleye/Internal/Constant.hs
@@ -14,7 +14,7 @@ import qualified Data.Text.Lazy                  as LT
 import qualified Data.ByteString                 as SBS
 import qualified Data.ByteString.Lazy            as LBS
 import qualified Data.Scientific                 as Sci
-import qualified Data.Time                       as Time
+import qualified Data.Time.Compat                as Time
 import qualified Data.UUID                       as UUID
 
 import qualified Data.Profunctor.Product         as PP
@@ -103,6 +103,9 @@ instance D.Default ToFields Time.ZonedTime (Column T.SqlTimestamptz) where
 
 instance D.Default ToFields Time.TimeOfDay (Column T.SqlTime) where
   def = toToFields T.sqlTimeOfDay
+
+instance D.Default ToFields Time.CalendarDiffTime (Column T.SqlInterval) where
+  def = toToFields T.sqlInterval
 
 instance D.Default ToFields (CI.CI ST.Text) (Column T.SqlCitext) where
   def = toToFields T.sqlCiStrictText

--- a/src/Opaleye/Internal/Inferrable.hs
+++ b/src/Opaleye/Internal/Inferrable.hs
@@ -21,7 +21,7 @@ import qualified Data.Profunctor.Product.Default as D
 import qualified Data.Scientific                 as Sci
 import qualified Data.Text.Lazy as LT
 import qualified Data.Text as ST
-import qualified Data.Time as Time
+import qualified Data.Time.Compat as Time
 import           Data.Typeable (Typeable)
 import           Data.UUID (UUID)
 import qualified Database.PostgreSQL.Simple.Range as R
@@ -96,6 +96,10 @@ instance localtime ~ Time.LocalTime
 
 instance timeofday ~ Time.TimeOfDay
   => D.Default (Inferrable FromField) T.SqlTime timeofday where
+  def = Inferrable D.def
+
+instance calendardifftime ~ Time.CalendarDiffTime
+  => D.Default (Inferrable FromField) T.SqlInterval calendardifftime where
   def = Inferrable D.def
 
 instance cttext ~ CI.CI ST.Text
@@ -204,6 +208,10 @@ instance C.Column T.SqlTimestamptz ~ cSqlTimestamptz
 
 instance C.Column T.SqlTime ~ cSqlTime
   => D.Default (Inferrable ToFields) Time.TimeOfDay cSqlTime where
+  def = Inferrable D.def
+
+instance C.Column T.SqlInterval ~ cSqlInterval
+  => D.Default (Inferrable ToFields) Time.CalendarDiffTime cSqlInterval where
   def = Inferrable D.def
 
 instance C.Column T.SqlCitext ~ cSqlCitext

--- a/src/Opaleye/Internal/PGTypes.hs
+++ b/src/Opaleye/Internal/PGTypes.hs
@@ -13,7 +13,7 @@ import qualified Data.Text.Lazy as LText
 import qualified Data.Text.Lazy.Encoding as LTextEncoding
 import qualified Data.ByteString as SByteString
 import qualified Data.ByteString.Lazy as LByteString
-import qualified Data.Time as Time
+import qualified Data.Time.Compat as Time
 import qualified Data.Time.Locale.Compat as Locale
 
 unsafePgFormatTime :: Time.FormatTime t => HPQ.Name -> String -> t -> Column c

--- a/src/Opaleye/Internal/PGTypesExternal.hs
+++ b/src/Opaleye/Internal/PGTypesExternal.hs
@@ -107,8 +107,8 @@ pgTimeOfDay = IPT.unsafePgFormatTime "time" "'%T%Q'"
 -- "We recommend not using the type time with time zone"
 -- http://www.postgresql.org/docs/8.3/static/datatype-datetime.html
 
-pgInterval :: Time.CalendarDiffTime -> Column PGInterval
-pgInterval = IPT.castToType "interval" . quote . Time.Format.ISO8601.iso8601Show
+sqlInterval :: Time.CalendarDiffTime -> Column PGInterval
+sqlInterval = IPT.castToType "interval" . quote . Time.Format.ISO8601.iso8601Show
     where
       quote s = "'" ++ s ++ "'"
 

--- a/src/Opaleye/Internal/RunQuery.hs
+++ b/src/Opaleye/Internal/RunQuery.hs
@@ -39,7 +39,7 @@ import qualified Data.Text.Lazy as LT
 import qualified Data.Text.Lazy.Encoding as LTE
 import qualified Data.ByteString as SBS
 import qualified Data.ByteString.Lazy as LBS
-import qualified Data.Time as Time
+import qualified Data.Time.Compat as Time
 import qualified Data.Scientific as Sci
 import qualified Data.String as String
 import           Data.UUID (UUID)
@@ -242,6 +242,9 @@ instance DefaultFromField T.SqlTimestamp Time.LocalTime where
   defaultFromField = fromPGSFromField
 
 instance DefaultFromField T.SqlTimestamptz Time.ZonedTime where
+  defaultFromField = fromPGSFromField
+
+instance DefaultFromField T.SqlInterval Time.CalendarDiffTime where
   defaultFromField = fromPGSFromField
 
 instance DefaultFromField T.SqlTime Time.TimeOfDay where

--- a/src/Opaleye/Operators.hs
+++ b/src/Opaleye/Operators.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE TypeSynonymInstances #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
 
 -- We can probably disable ConstraintKinds and TypeSynonymInstances
 -- when we move to Sql... instead of PG..
@@ -100,6 +101,9 @@ module Opaleye.Operators
   , timestamptzAtTimeZone
   , dateOfTimestamp
   , now
+  , IntervalNum
+  , addInterval
+  , minusInterval
   -- * Deprecated
   , exists
   , notExists
@@ -468,6 +472,27 @@ timestamptzAtTimeZone = C.binOp HPQ.OpAtTimeZone
 
 dateOfTimestamp :: F.Field T.SqlTimestamp -> F.Field T.SqlDate
 dateOfTimestamp (Column e) = Column (HPQ.FunExpr "date" [e])
+
+-- | @IntervalNum from to@ determines from which date or time types an interval
+-- can be added ('addInterval') or subtracted ('minusInterval`) and which is the
+-- resulting type.
+--
+-- The instances should correspond to the interval + and - operations listed in:
+--
+-- https://www.postgresql.org/docs/current/functions-datetime.html#OPERATORS-DATETIME-TABLE
+class IntervalNum from to
+
+instance IntervalNum T.SqlDate        T.SqlTimestamp
+instance IntervalNum T.SqlInterval    T.SqlInterval
+instance IntervalNum T.SqlTimestamp   T.SqlTimestamp
+instance IntervalNum T.SqlTimestamptz T.SqlTimestamptz
+instance IntervalNum T.SqlTime        T.SqlTime
+
+addInterval :: IntervalNum from to => F.Field from -> F.Field T.SqlInterval -> F.Field to
+addInterval = C.binOp (HPQ.:+)
+
+minusInterval :: IntervalNum from to => F.Field from -> F.Field T.SqlInterval -> F.Field to
+minusInterval = C.binOp (HPQ.:-)
 
 {-# DEPRECATED exists "Identical to 'restrictExists'.  Will be removed in version 0.8." #-}
 exists :: QueryArr a b -> QueryArr a ()

--- a/src/Opaleye/Operators.hs
+++ b/src/Opaleye/Operators.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE TypeSynonymInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE FunctionalDependencies #-}
 
 -- We can probably disable ConstraintKinds and TypeSynonymInstances
 -- when we move to Sql... instead of PG..
@@ -480,7 +481,7 @@ dateOfTimestamp (Column e) = Column (HPQ.FunExpr "date" [e])
 -- The instances should correspond to the interval + and - operations listed in:
 --
 -- https://www.postgresql.org/docs/current/functions-datetime.html#OPERATORS-DATETIME-TABLE
-class IntervalNum from to
+class IntervalNum from to | from -> to
 
 instance IntervalNum T.SqlDate        T.SqlTimestamp
 instance IntervalNum T.SqlInterval    T.SqlInterval

--- a/src/Opaleye/SqlTypes.hs
+++ b/src/Opaleye/SqlTypes.hs
@@ -23,11 +23,13 @@ module Opaleye.SqlTypes (
   sqlLocalTime,
   sqlZonedTime,
   sqlTimeOfDay,
+  sqlInterval,
   -- ** Types
   SqlDate,
   SqlTime,
   SqlTimestamp,
   SqlTimestamptz,
+  SqlInterval,
   -- * JSON
   -- ** Creating values
   sqlJSON,
@@ -96,6 +98,7 @@ import           Opaleye.Internal.PGTypesExternal (SqlBool,
                                                    SqlTime,
                                                    SqlTimestamp,
                                                    SqlTimestamptz,
+                                                   SqlInterval,
                                                    SqlUuid,
                                                    SqlCitext,
                                                    SqlArray,
@@ -112,7 +115,7 @@ import           Data.Int (Int64)
 import           Data.Scientific as Sci
 import qualified Data.Text as SText
 import qualified Data.Text.Lazy as LText
-import qualified Data.Time as Time
+import qualified Data.Time.Compat as Time
 import qualified Data.UUID as UUID
 
 import qualified Database.PostgreSQL.Simple.Range as R
@@ -170,6 +173,8 @@ sqlTimeOfDay = P.pgTimeOfDay
 -- "We recommend not using the type time with time zone"
 -- http://www.postgresql.org/docs/8.3/static/datatype-datetime.html
 
+sqlInterval :: Time.CalendarDiffTime -> F.Field SqlInterval
+sqlInterval = P.pgInterval
 
 sqlCiStrictText :: CI.CI SText.Text -> F.Field SqlCitext
 sqlCiStrictText = P.pgCiStrictText

--- a/src/Opaleye/SqlTypes.hs
+++ b/src/Opaleye/SqlTypes.hs
@@ -23,7 +23,7 @@ module Opaleye.SqlTypes (
   sqlLocalTime,
   sqlZonedTime,
   sqlTimeOfDay,
-  sqlInterval,
+  P.sqlInterval,
   -- ** Types
   SqlDate,
   SqlTime,
@@ -172,9 +172,6 @@ sqlTimeOfDay = P.pgTimeOfDay
 
 -- "We recommend not using the type time with time zone"
 -- http://www.postgresql.org/docs/8.3/static/datatype-datetime.html
-
-sqlInterval :: Time.CalendarDiffTime -> F.Field SqlInterval
-sqlInterval = P.pgInterval
 
 sqlCiStrictText :: CI.CI SText.Text -> F.Field SqlCitext
 sqlCiStrictText = P.pgCiStrictText


### PR DESCRIPTION
This adds the `SqlInterval` type matching PostgreSQL's `interval` type.

`SqlInterval` can be converted to Haskell's `CalendarDiffTime` type.

The operations `addInterval` and `minusInterval` have been added:

```
addInterval, minusInterval
  :: IntervalNum from to
  => F.Field from
  -> F.Field T.SqlInterval
  -> F.Field to
```

They add or subtract an interval from various date and time types. Which types are allowed to add or subtract an interval from and which type is the resulting type is determined by the:

```
class IntervalNum from to

instance IntervalNum T.SqlDate        T.SqlTimestamp
instance IntervalNum T.SqlInterval    T.SqlInterval
instance IntervalNum T.SqlTimestamp   T.SqlTimestamp
instance IntervalNum T.SqlTimestamptz T.SqlTimestamptz
instance IntervalNum T.SqlTime        T.SqlTime
```

Simple test cases have been added to test these operations.

This fixes #509.