### PR TITLE
Fix date literals

### DIFF
--- a/Test/Test.hs
+++ b/Test/Test.hs
@@ -6,13 +6,11 @@
 module Main where
 
 import qualified Configuration.Dotenv             as Dotenv
-import qualified Connection
 import           Control.Applicative              ((<$>), (<*>), (<|>))
 import qualified Control.Applicative              as A
 import           Control.Arrow                    ((&&&), (***), (<<<), (>>>))
 import qualified Control.Arrow                    as Arr
 import qualified Data.Aeson                       as Json
-import qualified Data.ByteString                  as SBS
 import qualified Data.Function                    as F
 import qualified Data.List                        as L
 import           Data.Monoid                      ((<>))
@@ -21,9 +19,10 @@ import qualified Data.Profunctor                  as P
 import qualified Data.Profunctor.Product          as PP
 import qualified Data.Profunctor.Product.Default  as D
 import qualified Data.String                      as String
+import qualified Data.ByteString                  as SBS
 import qualified Data.Text                        as T
-import qualified Data.Time.Clock.POSIX.Compat     as Time
 import qualified Data.Time.Compat                 as Time
+import qualified Data.Time.Clock.POSIX.Compat     as Time
 import qualified Database.PostgreSQL.Simple       as PGS
 import qualified Database.PostgreSQL.Simple.Range as R
 import           GHC.Int                          (Int64)
@@ -31,15 +30,16 @@ import           Opaleye                          (Field, Nullable, Select,
                                                    SelectArr, (.==), (.>))
 import qualified Opaleye                          as O
 import qualified Opaleye.Internal.Aggregate       as IA
-import           Opaleye.Internal.Locking         as OL
-import           Opaleye.Internal.MaybeFields     as OM
 import           Opaleye.Internal.RunQuery        (DefaultFromField)
+import           Opaleye.Internal.MaybeFields     as OM
+import           Opaleye.Internal.Locking         as OL
+import qualified Connection
 import qualified QuickCheck
 import           System.Environment               (lookupEnv)
 import           Test.Hspec
 import qualified TypeFamilies                     ()
 
-import           Opaleye.Manipulation             (Delete (Delete))
+import Opaleye.Manipulation (Delete (Delete))
 
 {-
 

--- a/opaleye-sqlite/src/Opaleye/SQLite/PGTypes.hs
+++ b/opaleye-sqlite/src/Opaleye/SQLite/PGTypes.hs
@@ -2,22 +2,22 @@
 
 module Opaleye.SQLite.PGTypes (module Opaleye.SQLite.PGTypes) where
 
-import           Opaleye.SQLite.Internal.Column                (Column)
-import qualified Opaleye.SQLite.Internal.Column                as C
-import qualified Opaleye.SQLite.Internal.PGTypes               as IPT
+import           Opaleye.SQLite.Internal.Column (Column)
+import qualified Opaleye.SQLite.Internal.Column as C
+import qualified Opaleye.SQLite.Internal.PGTypes as IPT
 
-import qualified Opaleye.SQLite.Internal.HaskellDB.PrimQuery   as HPQ
+import qualified Opaleye.SQLite.Internal.HaskellDB.PrimQuery as HPQ
 import qualified Opaleye.SQLite.Internal.HaskellDB.Sql.Default as HSD (quote)
 
-import qualified Data.ByteString                               as SByteString
-import qualified Data.ByteString.Lazy                          as LByteString
-import qualified Data.CaseInsensitive                          as CI
-import qualified Data.Text                                     as SText
-import qualified Data.Text.Lazy                                as LText
-import qualified Data.Time                                     as Time
-import qualified Data.UUID                                     as UUID
+import qualified Data.CaseInsensitive as CI
+import qualified Data.Text as SText
+import qualified Data.Text.Lazy as LText
+import qualified Data.ByteString as SByteString
+import qualified Data.ByteString.Lazy as LByteString
+import qualified Data.Time as Time
+import qualified Data.UUID as UUID
 
-import           Data.Int                                      (Int64)
+import           Data.Int (Int64)
 
 data PGBool
 data PGDate

--- a/opaleye.cabal
+++ b/opaleye.cabal
@@ -41,6 +41,7 @@ library
     , semigroups          >= 0.13    && < 0.20
     , text                >= 0.11    && < 1.3
     , transformers        >= 0.3     && < 0.6
+    , time                >= 1.9.3   && < 2
     , time-compat         >= 1.9.5   && < 1.12
     , time-locale-compat  >= 0.1     && < 0.2
     , uuid                >= 1.3     && < 1.4

--- a/src/Opaleye/Internal/PGTypes.hs
+++ b/src/Opaleye/Internal/PGTypes.hs
@@ -2,24 +2,22 @@
 
 module Opaleye.Internal.PGTypes where
 
-import           Opaleye.Internal.Column              (Column (Column))
-import qualified Opaleye.Internal.Column              as C
+import           Opaleye.Internal.Column (Column(Column))
+import qualified Opaleye.Internal.Column as C
 import qualified Opaleye.Internal.HaskellDB.PrimQuery as HPQ
 
-import qualified Data.ByteString                      as SByteString
-import qualified Data.ByteString.Lazy                 as LByteString
-import           Data.Proxy                           (Proxy (..))
-import qualified Data.Text                            as SText
-import qualified Data.Text.Encoding                   as STextEncoding
-import qualified Data.Text.Lazy                       as LText
-import qualified Data.Text.Lazy.Encoding              as LTextEncoding
-import qualified Data.Time.Format.ISO8601             as Time
+import           Data.Proxy (Proxy(..))
+import qualified Data.Text as SText
+import qualified Data.Text.Encoding as STextEncoding
+import qualified Data.Text.Lazy as LText
+import qualified Data.Text.Lazy.Encoding as LTextEncoding
+import qualified Data.ByteString as SByteString
+import qualified Data.ByteString.Lazy as LByteString
+import qualified Data.Time.Format.ISO8601 as Time
 
 unsafePgFormatTime :: Time.ISO8601 t => HPQ.Name -> t -> Column c
 unsafePgFormatTime typeName = castToType typeName . format
-    where
-      format  = quote . Time.iso8601Show
-      quote s = "'" ++ s ++ "'"
+  where format s = "'" ++ Time.iso8601Show s ++ "'"
 
 literalColumn :: forall a. IsSqlType a => HPQ.Literal -> Column a
 literalColumn = Column . HPQ.CastExpr (showSqlType (Proxy :: Proxy a)) . HPQ.ConstExpr

--- a/src/Opaleye/Internal/PGTypes.hs
+++ b/src/Opaleye/Internal/PGTypes.hs
@@ -2,23 +2,24 @@
 
 module Opaleye.Internal.PGTypes where
 
-import           Opaleye.Internal.Column (Column(Column))
-import qualified Opaleye.Internal.Column as C
+import           Opaleye.Internal.Column              (Column (Column))
+import qualified Opaleye.Internal.Column              as C
 import qualified Opaleye.Internal.HaskellDB.PrimQuery as HPQ
 
-import           Data.Proxy (Proxy(..))
-import qualified Data.Text as SText
-import qualified Data.Text.Encoding as STextEncoding
-import qualified Data.Text.Lazy as LText
-import qualified Data.Text.Lazy.Encoding as LTextEncoding
-import qualified Data.ByteString as SByteString
-import qualified Data.ByteString.Lazy as LByteString
-import qualified Data.Time.Compat as Time
-import qualified Data.Time.Locale.Compat as Locale
+import qualified Data.ByteString                      as SByteString
+import qualified Data.ByteString.Lazy                 as LByteString
+import           Data.Proxy                           (Proxy (..))
+import qualified Data.Text                            as SText
+import qualified Data.Text.Encoding                   as STextEncoding
+import qualified Data.Text.Lazy                       as LText
+import qualified Data.Text.Lazy.Encoding              as LTextEncoding
+import qualified Data.Time.Format.ISO8601             as Time
 
-unsafePgFormatTime :: Time.FormatTime t => HPQ.Name -> String -> t -> Column c
-unsafePgFormatTime typeName formatString = castToType typeName . format
-  where format = Time.formatTime Locale.defaultTimeLocale formatString
+unsafePgFormatTime :: Time.ISO8601 t => HPQ.Name -> t -> Column c
+unsafePgFormatTime typeName = castToType typeName . format
+    where
+      format  = quote . Time.iso8601Show
+      quote s = "'" ++ s ++ "'"
 
 literalColumn :: forall a. IsSqlType a => HPQ.Literal -> Column a
 literalColumn = Column . HPQ.CastExpr (showSqlType (Proxy :: Proxy a)) . HPQ.ConstExpr

--- a/src/Opaleye/Internal/PGTypesExternal.hs
+++ b/src/Opaleye/Internal/PGTypesExternal.hs
@@ -120,9 +120,7 @@ pgTimeOfDay = IPT.unsafePgFormatTime "time"
 -- http://www.postgresql.org/docs/8.3/static/datatype-datetime.html
 
 sqlInterval :: Time.CalendarDiffTime -> Column PGInterval
-sqlInterval = IPT.castToType "interval" . quote . Time.Format.ISO8601.iso8601Show
-    where
-      quote s = "'" ++ s ++ "'"
+sqlInterval = IPT.unsafePgFormatTime "interval"
 
 pgCiStrictText :: CI.CI SText.Text -> Column PGCitext
 pgCiStrictText = IPT.literalColumn . HPQ.StringLit . SText.unpack . CI.original

--- a/src/Opaleye/Internal/PGTypesExternal.hs
+++ b/src/Opaleye/Internal/PGTypesExternal.hs
@@ -102,19 +102,19 @@ pgUUID :: UUID.UUID -> Column PGUuid
 pgUUID = IPT.literalColumn . HPQ.StringLit . UUID.toString
 
 pgDay :: Time.Day -> Column PGDate
-pgDay = IPT.unsafePgFormatTime "date" "'%0Y-%m-%d'"
+pgDay = IPT.unsafePgFormatTime "date"
 
 pgUTCTime :: Time.UTCTime -> Column PGTimestamptz
-pgUTCTime = IPT.unsafePgFormatTime "timestamptz" "'%0Y-%m-%dT%T%QZ'"
+pgUTCTime = IPT.unsafePgFormatTime "timestamptz"
 
 pgLocalTime :: Time.LocalTime -> Column PGTimestamp
-pgLocalTime = IPT.unsafePgFormatTime "timestamp" "'%0Y-%m-%dT%T%Q'"
+pgLocalTime = IPT.unsafePgFormatTime "timestamp"
 
 pgZonedTime :: Time.ZonedTime -> Column PGTimestamptz
-pgZonedTime = IPT.unsafePgFormatTime "timestamptz" "'%0Y-%m-%dT%T%Q%z'"
+pgZonedTime = IPT.unsafePgFormatTime "timestamptz"
 
 pgTimeOfDay :: Time.TimeOfDay -> Column PGTime
-pgTimeOfDay = IPT.unsafePgFormatTime "time" "'%T%Q'"
+pgTimeOfDay = IPT.unsafePgFormatTime "time"
 
 -- "We recommend not using the type time with time zone"
 -- http://www.postgresql.org/docs/8.3/static/datatype-datetime.html

--- a/src/Opaleye/Internal/PGTypesExternal.hs
+++ b/src/Opaleye/Internal/PGTypesExternal.hs
@@ -1,32 +1,31 @@
-{-# LANGUAGE EmptyDataDecls       #-}
-{-# LANGUAGE ScopedTypeVariables  #-}
+{-# LANGUAGE EmptyDataDecls #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeSynonymInstances #-}
 
 module Opaleye.Internal.PGTypesExternal
   (module Opaleye.Internal.PGTypesExternal, IsSqlType(..)) where
 
-import           Opaleye.Internal.Column                (Column)
-import qualified Opaleye.Internal.Column                as C
-import           Opaleye.Internal.PGTypes               (IsSqlType (..))
-import qualified Opaleye.Internal.PGTypes               as IPT
+import           Opaleye.Internal.Column (Column)
+import qualified Opaleye.Internal.Column as C
+import qualified Opaleye.Internal.PGTypes as IPT
+import           Opaleye.Internal.PGTypes (IsSqlType(..))
 
-import qualified Opaleye.Internal.HaskellDB.PrimQuery   as HPQ
+import qualified Opaleye.Internal.HaskellDB.PrimQuery as HPQ
 import qualified Opaleye.Internal.HaskellDB.Sql.Default as HSD
 
-import qualified Data.Aeson                             as Ae
-import qualified Data.ByteString                        as SByteString
-import qualified Data.ByteString.Lazy                   as LByteString
-import qualified Data.CaseInsensitive                   as CI
-import           Data.Scientific                        as Sci
-import qualified Data.Text                              as SText
-import qualified Data.Text.Lazy                         as LText
-import qualified Data.Time.Compat                       as Time
-import qualified Data.Time.Format.ISO8601.Compat        as Time.Format.ISO8601
-import qualified Data.UUID                              as UUID
+import qualified Data.CaseInsensitive as CI
+import qualified Data.Aeson as Ae
+import qualified Data.Text as SText
+import qualified Data.Text.Lazy as LText
+import qualified Data.ByteString as SByteString
+import qualified Data.ByteString.Lazy as LByteString
+import           Data.Scientific as Sci
+import qualified Data.Time.Compat as Time
+import qualified Data.UUID as UUID
 
-import           Data.Int                               (Int64)
+import           Data.Int (Int64)
 
-import qualified Database.PostgreSQL.Simple.Range       as R
+import qualified Database.PostgreSQL.Simple.Range as R
 
 instance C.SqlNum SqlFloat8 where
   sqlFromInteger = pgDouble . fromInteger


### PR DESCRIPTION
Reason why this is needed: Postgresql doesn't know how to parse:
`25-10-20T22:36:00Z` because both `d-m-y` and `y-m-d` formats could work.
Will add explicit padding to `year` to make it clear.

The previous format `%F` is `%Y-%m-%d` where `%Y` is unpadded. 

The behaviour is illustrated below:
```
=> select '02-10-20T22:36:00Z' :: timestamp;
  timestamp
  ---------------------
  2020-02-10 22:36:00



=> select '0020-10-20T22:36:00Z' :: timestamp;
  timestamp
  ---------------------
  0020-10-20 22:36:00



=> select '020-10-20T22:36:00Z' :: timestamp;
  timestamp
  ---------------------
  0020-10-20 22:36:00



=> select '20-10-20T22:36:00Z' :: timestamp;
  ERROR:  22008: date/time field value out of range: "20-10-20T22:36:00Z"
  LINE 1: select '20-10-20T22:36:00Z' :: timestamp; ^
  HINT:  Perhaps you need a different "datestyle" setting.
  LOCATION:  DateTimeParseError, datetime.c:3763

=> select '12-10-20T22:36:00Z' :: timestamp;
  timestamp
  ---------------------
  2020-12-10 22:36:00

=> select '25-10-20T22:36:00Z' :: timestamp;
  ERROR:  22008: date/time field value out of range: "25-10-20T22:36:00Z" 
  LINE 1: select '25-10-20T22:36:00Z' :: timestamp;               ^
  HINT:  Perhaps you need a different "datestyle" setting.
  LOCATION:  DateTimeParseError, datetime.c:3763

=> select '020-10-20T22:36:00Z' :: timestamp;
  timestamp
  ---------------------
    0020-10-20 22:36:00
    (1 row)

```

For SQLite, the `datetime` function produces `NULL` for the non-padded versions. 