### PR TITLE
Fixes for invalid SQL generated in WITH queries

### DIFF
--- a/Test/Test.hs
+++ b/Test/Test.hs
@@ -25,6 +25,7 @@ import qualified Data.ByteString                  as SBS
 import qualified Data.Text                        as T
 import qualified Data.Time.Compat                 as Time
 import qualified Data.Time.Clock.POSIX.Compat     as Time
+import           Data.Tuple (swap)
 import qualified Database.PostgreSQL.Simple       as PGS
 import qualified Database.PostgreSQL.Simple.Range as R
 import           GHC.Int                          (Int64)
@@ -838,6 +839,12 @@ testNestedWith = it "with nested within with" $ testH with (`shouldBe` expected)
     with = O.with table1Q $ \t -> O.with table2Q $ \u -> (,) <$> t <*> u
     expected = (,) <$> table1data <*> table2data
 
+testWithRebind :: Test
+testWithRebind = it "with (rebinding)" $ testH with (`shouldBe` expected)
+  where
+    with = O.with (fmap swap table1Q) $ \t -> (,) <$> t <*> table2Q
+    expected = (,) <$> fmap swap table1data <*> table2data
+
 -- TODO: This is getting too complicated
 testUpdate :: Test
 testUpdate = it "" $ \conn -> do
@@ -1604,5 +1611,6 @@ main = do
         testWithRecursive
         testWith
         testNestedWith
+        testWithRebind
       describe "relation valued exprs" $ do
         testUnnest

--- a/Test/Test.hs
+++ b/Test/Test.hs
@@ -832,6 +832,12 @@ testWith = it "with" $ testH with (`shouldBe` expected)
   where with = O.with table1Q $ \t -> (,) <$> t <*> table2Q
         expected = (,) <$> table1data <*> table2data
 
+testNestedWith :: Test
+testNestedWith = it "with nested within with" $ testH with (`shouldBe` expected)
+  where
+    with = O.with table1Q $ \t -> O.with table2Q $ \u -> (,) <$> t <*> u
+    expected = (,) <$> table1data <*> table2data
+
 -- TODO: This is getting too complicated
 testUpdate :: Test
 testUpdate = it "" $ \conn -> do
@@ -1597,5 +1603,6 @@ main = do
       describe "with" $ do
         testWithRecursive
         testWith
+        testNestedWith
       describe "relation valued exprs" $ do
         testUnnest

--- a/src/Opaleye/Internal/PrimQuery.hs
+++ b/src/Opaleye/Internal/PrimQuery.hs
@@ -63,6 +63,9 @@ aSemijoin joint existsQ = PrimQueryArr $ \_ primQ -> Semijoin joint primQ exists
 aRebind :: Bindings HPQ.PrimExpr -> PrimQueryArr
 aRebind bindings = PrimQueryArr $ \_ -> Rebind True bindings
 
+aRebindNoStar :: Bindings HPQ.PrimExpr -> PrimQueryArr
+aRebindNoStar bindings = PrimQueryArr $ \_ -> Rebind False bindings
+
 aRestrict :: HPQ.PrimExpr -> PrimQueryArr
 aRestrict predicate = PrimQueryArr $ \_ -> restrict predicate
 

--- a/src/Opaleye/Internal/Rebind.hs
+++ b/src/Opaleye/Internal/Rebind.hs
@@ -21,3 +21,10 @@ rebindExplicitPrefix prefix u = selectArr $ do
   pure $ \a ->
     let (b, bindings) = PM.run (runUnpackspec u (PM.extractAttr prefix tag) a)
     in (b, PQ.aRebind bindings)
+
+rebindExplicitPrefixNoStar :: String -> Unpackspec a b -> SelectArr a b
+rebindExplicitPrefixNoStar prefix u = selectArr $ do
+  tag <- Tag.fresh
+  pure $ \a ->
+    let (b, bindings) = PM.run (runUnpackspec u (PM.extractAttr prefix tag) a)
+    in (b, PQ.aRebindNoStar bindings)

--- a/src/Opaleye/Internal/Sql.hs
+++ b/src/Opaleye/Internal/Sql.hs
@@ -265,7 +265,12 @@ binary op (select1, select2) = SelectBinary Binary {
   }
 
 with :: PQ.Recursive -> Symbol -> [Symbol] -> Select -> Select -> Select
-with recursive name cols wWith wSelect = SelectWith $ With {..}
+with recursive name cols wWith wSelect =
+  SelectFrom
+    newSelect
+      { attrs = Star
+      , tables = [(NonLateral, SelectWith $ With {..}, Nothing)]
+      }
   where
    wTable = HSql.SqlTable Nothing (sqlSymbol name)
    wRecursive = case recursive of

--- a/src/Opaleye/Internal/Sql.hs
+++ b/src/Opaleye/Internal/Sql.hs
@@ -278,6 +278,7 @@ with recursive name cols wWith wSelect =
      PQ.Recursive -> Recursive
    wCols = map (HSql.SqlColumn . sqlSymbol) cols
 
+
 joinType :: PQ.JoinType -> JoinType
 joinType PQ.LeftJoin = LeftJoin
 joinType PQ.RightJoin = RightJoin

--- a/src/Opaleye/Internal/Sql.hs
+++ b/src/Opaleye/Internal/Sql.hs
@@ -3,7 +3,7 @@
 
 module Opaleye.Internal.Sql where
 
-import           Prelude hiding (product)
+import           Prelude hiding (filter, product)
 
 import qualified Opaleye.Internal.PrimQuery as PQ
 

--- a/src/Opaleye/Internal/Sql.hs
+++ b/src/Opaleye/Internal/Sql.hs
@@ -264,7 +264,7 @@ binary op (select1, select2) = SelectBinary Binary {
   bSelect2 = select2
   }
 
-with :: PQ.Recursive -> Symbol -> [Symbol]-> Select -> Select -> Select
+with :: PQ.Recursive -> Symbol -> [Symbol] -> Select -> Select -> Select
 with recursive name cols wWith wSelect = SelectWith $ With {..}
   where
    wTable = HSql.SqlTable Nothing (sqlSymbol name)


### PR DESCRIPTION
This PR contains two fixes pertaining to `WITH` queries. The first wraps an otherwise pointless `SELECT * FROM` around `WITH` queries to workaround PostgreSQL's arbitrary rejection of `WITH foo AS (_) WITH bar AS (_) _` as invalid syntax. The second fixes a more serious issue whereby `withExplicit` is missing a `Rebind` and can generate a "valid" query that silently produces incorrect results.