### PR TITLE
Fix bug preventing `orderedAggregate` and `distinctAggregator` from being used together

### DIFF
--- a/Test/Test.hs
+++ b/Test/Test.hs
@@ -15,6 +15,7 @@ import qualified Data.Aeson                       as Json
 import qualified Data.Function                    as F
 import           Data.Int (Int32)
 import qualified Data.List                        as L
+import qualified Data.List.NonEmpty               as NE
 import           Data.Monoid                      ((<>))
 import qualified Data.Ord                         as Ord
 import qualified Data.Profunctor                  as P
@@ -617,6 +618,21 @@ testStringArrayAggregateOrdered = it "" $ q `selectShouldReturnSorted` expected
                       )
                      ]
         sortedData = L.sortBy (Ord.comparing snd) table7data
+
+
+testStringArrayAggregateOrderedDistinct :: Test
+testStringArrayAggregateOrderedDistinct = it "" $ q `selectShouldReturnSorted` expected
+  where q =
+          O.aggregateOrdered
+            (O.asc snd)
+            (PP.p2 (O.arrayAgg, O.distinctAggregator . O.stringAgg . O.sqlString $ ","))
+            table7Q
+        expected = [( map fst sortedData
+                      , L.intercalate "," $ map NE.head $ NE.group $ map snd sortedData
+                      )
+                     ]
+        sortedData = L.sortBy (Ord.comparing snd) table7data
+
 
 -- | Using orderAggregate you can apply different orderings to
 -- different aggregates.
@@ -1524,6 +1540,7 @@ main = do
         testOverwriteAggregateOrdered
         testMultipleAggregateOrdered
         testStringArrayAggregateOrdered
+        testStringArrayAggregateOrderedDistinct
         testDistinctAndAggregate
         testDoubleAggregate
       describe "distinct" $ do

--- a/opaleye.cabal
+++ b/opaleye.cabal
@@ -29,8 +29,9 @@ library
       aeson               >= 0.6     && < 2.3
     , base                >= 4.9     && < 4.19
     , base16-bytestring   >= 0.1.1.6 && < 1.1
-    , case-insensitive    >= 1.2     && < 1.3
     , bytestring          >= 0.10    && < 0.12
+    , case-insensitive    >= 1.2     && < 1.3
+    , containers          >= 0.5     && < 0.8
     , contravariant       >= 1.2     && < 1.6
     , postgresql-simple   >= 0.6     && < 0.8
     , pretty              >= 1.1.1.0 && < 1.2

--- a/src/Opaleye/Internal/Aggregate.hs
+++ b/src/Opaleye/Internal/Aggregate.hs
@@ -2,6 +2,8 @@
 module Opaleye.Internal.Aggregate where
 
 import           Control.Applicative (Applicative, liftA2, pure, (<*>))
+import           Data.Foldable (toList)
+import           Data.Traversable (for)
 
 import qualified Data.Profunctor as P
 import qualified Data.Profunctor.Product as PP
@@ -12,6 +14,7 @@ import qualified Opaleye.Internal.Order as O
 import qualified Opaleye.Internal.PackMap as PM
 import qualified Opaleye.Internal.PrimQuery as PQ
 import qualified Opaleye.Internal.Tag as T
+import qualified Opaleye.Internal.Unpackspec as U
 import qualified Opaleye.SqlTypes as T
 
 import qualified Opaleye.Internal.HaskellDB.PrimQuery as HPQ
@@ -30,18 +33,27 @@ type @a@ to a single row of type @b@, a 'Control.Foldl.Fold' @a@ @b@
 takes a list of @a@ and returns a single value of type @b@.
 -}
 newtype Aggregator a b =
-  Aggregator (PM.PackMap (HPQ.Aggr, HPQ.PrimExpr) HPQ.PrimExpr a b)
+  Aggregator (PM.PackMap HPQ.Aggregate HPQ.PrimExpr a b)
 
 makeAggr' :: Maybe HPQ.AggrOp -> Aggregator (C.Field_ n a) (C.Field_ n' b)
 makeAggr' mAggrOp = P.dimap C.unColumn C.Column $ Aggregator (PM.PackMap
-  (\f e -> f (aggr, e)))
+  (\f e -> f (aggr e)))
   where
     aggr = case mAggrOp of
       Nothing -> HPQ.GroupBy
-      Just op -> HPQ.Aggr op [] HPQ.AggrAll Nothing
+      Just op -> \e -> HPQ.Aggregate (HPQ.Aggr op [e] [] HPQ.AggrAll Nothing)
 
 makeAggr :: HPQ.AggrOp -> Aggregator (C.Field_ n a) (C.Field_ n' b)
 makeAggr = makeAggr' . Just
+
+makeAggrExplicit :: U.Unpackspec a a -> HPQ.AggrOp -> Aggregator a (C.Field_ n b)
+makeAggrExplicit unpackspec op =
+  C.Column <$> Aggregator (PM.PackMap (\f e -> f (aggr e)))
+  where
+    aggr a = HPQ.Aggregate (HPQ.Aggr op exprs [] HPQ.AggrAll Nothing)
+      where
+        exprs = U.collectPEs unpackspec a
+
 
 -- | Order the values within each aggregation in `Aggregator` using
 -- the given ordering. This is only relevant for aggregations that
@@ -81,18 +93,18 @@ makeAggr = makeAggr' . Just
 
 orderAggregate :: O.Order a -> Aggregator a b -> Aggregator a b
 orderAggregate o (Aggregator (PM.PackMap pm)) = Aggregator (PM.PackMap
-  (\f c -> pm (f . P.first' (setOrder (O.orderExprs c o))) c))
+  (\f c -> pm (f . setOrder (O.orderExprs c o)) c))
   where
-    setOrder _ HPQ.GroupBy = HPQ.GroupBy
-    setOrder order aggr =
-      aggr
+    setOrder _ (HPQ.GroupBy e) = HPQ.GroupBy e
+    setOrder order (HPQ.Aggregate aggr) =
+      HPQ.Aggregate aggr
         { HPQ.aggrOrder = order
         }
 
 runAggregator
   :: Applicative f
   => Aggregator a b
-  -> ((HPQ.Aggr, HPQ.PrimExpr) -> f HPQ.PrimExpr)
+  -> (HPQ.Aggregate -> f HPQ.PrimExpr)
   -> a -> f b
 runAggregator (Aggregator a) = PM.traversePM a
 
@@ -127,24 +139,31 @@ aggregateU agg (c0, primQ, t0) = (c1, primQ')
           PM.run (runAggregator agg (extractAggregateFields t0) c0)
 
         projPEs = map fst projPEs_inners
-        inners  = map snd projPEs_inners
+        inners  = concatMap snd projPEs_inners
 
         primQ' = PQ.Aggregate projPEs (PQ.Rebind True inners primQ)
 
 extractAggregateFields
-  :: T.Tag
-  -> (m, HPQ.PrimExpr)
+  :: Traversable t
+  => T.Tag
+  -> (t HPQ.PrimExpr)
   -> PM.PM [((HPQ.Symbol,
-              (m, HPQ.Symbol)),
-              (HPQ.Symbol, HPQ.PrimExpr))]
+              t HPQ.Symbol),
+              PQ.Bindings HPQ.PrimExpr)]
            HPQ.PrimExpr
-extractAggregateFields tag (m, pe) = do
+extractAggregateFields tag agg = do
   i <- PM.new
 
   let souter = HPQ.Symbol ("result" ++ i) tag
-      sinner = HPQ.Symbol ("inner" ++ i) tag
 
-  PM.write ((souter, (m, sinner)), (sinner, pe))
+  bindings <- for agg $ \pe -> do
+    j <- PM.new
+    let sinner = HPQ.Symbol ("inner" ++ j) tag
+    pure (sinner, pe)      
+
+  let agg' = fmap fst bindings
+
+  PM.write ((souter, agg'), toList bindings)
 
   pure (HPQ.AttrExpr souter)
 
@@ -169,12 +188,12 @@ filterWhereInternal
 filterWhereInternal maybeField predicate aggregator =
   case liftA2 maybeField true aggregator of
     Aggregator (PM.PackMap pm) ->
-      Aggregator (PM.PackMap (\f c -> pm (f . P.first' (setFilter c)) c))
+      Aggregator (PM.PackMap (\f c -> pm (f . setFilter c) c))
   where
     true = P.lmap (const (T.sqlBool True)) (makeAggr HPQ.AggrBoolAnd)
-    setFilter _ HPQ.GroupBy = HPQ.GroupBy
-    setFilter row aggr =
-      aggr
+    setFilter _ (HPQ.GroupBy e) = HPQ.GroupBy e
+    setFilter row (HPQ.Aggregate aggr) =
+      HPQ.Aggregate aggr
         { HPQ.aggrFilter = aggrFilter'
         }
       where

--- a/src/Opaleye/Internal/HaskellDB/PrimQuery.hs
+++ b/src/Opaleye/Internal/HaskellDB/PrimQuery.hs
@@ -17,7 +17,7 @@ type Name = String
 type Scheme     = [Attribute]
 type Assoc      = [(Attribute,PrimExpr)]
 
-data Symbol = Symbol String T.Tag deriving (Read, Show)
+data Symbol = Symbol String T.Tag deriving (Eq, Ord, Read, Show)
 
 data PrimExpr   = AttrExpr  Symbol
                 | BaseTableAttrExpr Attribute
@@ -40,7 +40,7 @@ data PrimExpr   = AttrExpr  Symbol
                 | ArrayExpr [PrimExpr] -- ^ ARRAY[..]
                 | RangeExpr String BoundExpr BoundExpr
                 | ArrayIndex PrimExpr PrimExpr
-                deriving (Read,Show)
+                deriving (Eq, Ord, Read, Show)
 
 data Literal = NullLit
              | DefaultLit            -- ^ represents a default value
@@ -51,7 +51,7 @@ data Literal = NullLit
              | DoubleLit Double
              | NumericLit Sci.Scientific
              | OtherLit String       -- ^ used for hacking in custom SQL
-               deriving (Read,Show)
+               deriving (Eq, Ord, Read, Show)
 
 data BinOp      = (:==) | (:<) | (:<=) | (:>) | (:>=) | (:<>)
                 | OpAnd | OpOr
@@ -66,7 +66,7 @@ data BinOp      = (:==) | (:<) | (:<=) | (:>) | (:>=) | (:<>)
                 | (:->) | (:->>) | (:#>) | (:#>>)
                 | (:@>) | (:<@) | (:?) | (:?|) | (:?&)
                 | (:&&) | (:<<) | (:>>) | (:&<) | (:&>) | (:-|-)
-                deriving (Show,Read)
+                deriving (Eq, Ord, Read, Show)
 
 data UnOp = OpNot
           | OpIsNull
@@ -77,22 +77,22 @@ data UnOp = OpNot
           | OpLower
           | OpUpper
           | UnOpOther String
-          deriving (Show,Read)
+          deriving (Eq, Ord, Read, Show)
 
 data AggrOp     = AggrCount | AggrSum | AggrAvg | AggrMin | AggrMax
                 | AggrStdDev | AggrStdDevP | AggrVar | AggrVarP
                 | AggrBoolOr | AggrBoolAnd | AggrArr | JsonArr
                 | AggrStringAggr
                 | AggrOther String
-                deriving (Show,Read)
+                deriving (Eq, Ord, Read, Show)
 
 data AggrDistinct = AggrDistinct | AggrAll
-                  deriving (Eq,Show,Read)
+                  deriving (Eq, Ord, Read, Show)
 
 type Aggregate = Aggregate' PrimExpr
 
 data Aggregate' a = GroupBy a | Aggregate (Aggr' a)
-  deriving (Functor, Foldable, Traversable, Show, Read)
+  deriving (Functor, Foldable, Traversable, Eq, Ord, Read, Show)
 
 type Aggr = Aggr' PrimExpr
 
@@ -103,23 +103,25 @@ data Aggr' a = Aggr
   , aggrDistinct :: !AggrDistinct
   , aggrFilter :: !(Maybe PrimExpr)
   }
-  deriving (Functor, Foldable, Traversable, Show, Read)
+  deriving (Functor, Foldable, Traversable, Eq, Ord, Read, Show)
 
-data OrderExpr = OrderExpr OrderOp PrimExpr
-               deriving (Show,Read)
+type OrderExpr = OrderExpr' PrimExpr
+
+data OrderExpr' a = OrderExpr OrderOp a
+  deriving (Functor, Foldable, Traversable, Eq, Ord, Read, Show)
 
 data OrderNulls = NullsFirst | NullsLast
-                deriving (Show,Read)
+                deriving (Eq, Ord, Read, Show)
 
 data OrderDirection = OpAsc | OpDesc
-                    deriving (Show,Read)
+                    deriving (Eq, Ord, Read, Show)
 
 data OrderOp = OrderOp { orderDirection :: OrderDirection
                        , orderNulls     :: OrderNulls }
-               deriving (Show,Read)
+               deriving (Eq, Ord, Read, Show)
 
 data BoundExpr = Inclusive PrimExpr | Exclusive PrimExpr | PosInfinity | NegInfinity
-                 deriving (Show,Read)
+                 deriving (Eq, Ord, Read, Show)
 
 data WndwOp
   = WndwRowNumber
@@ -134,10 +136,10 @@ data WndwOp
   | WndwLastValue PrimExpr
   | WndwNthValue PrimExpr PrimExpr
   | WndwAggregate AggrOp [PrimExpr]
-  deriving (Show,Read)
+  deriving (Eq, Ord, Read, Show)
 
 data Partition = Partition
   { partitionBy :: [PrimExpr]
   , orderBy :: [OrderExpr]
   }
-  deriving (Read, Show)
+  deriving (Eq, Ord, Read, Show)

--- a/src/Opaleye/Internal/HaskellDB/PrimQuery.hs
+++ b/src/Opaleye/Internal/HaskellDB/PrimQuery.hs
@@ -2,6 +2,8 @@
 --                HWT Group (c) 2003, haskelldb-users@lists.sourceforge.net
 -- License     :  BSD-style
 
+{-# LANGUAGE DeriveTraversable #-}
+
 module Opaleye.Internal.HaskellDB.PrimQuery where
 
 import qualified Opaleye.Internal.Tag as T
@@ -22,7 +24,7 @@ data PrimExpr   = AttrExpr  Symbol
                 | CompositeExpr     PrimExpr Attribute -- ^ Composite Type Query
                 | BinExpr   BinOp PrimExpr PrimExpr
                 | UnExpr    UnOp PrimExpr
-                | AggrExpr  AggrDistinct AggrOp PrimExpr [OrderExpr] (Maybe PrimExpr)
+                | AggrExpr  Aggr
                 | WndwExpr  WndwOp Partition
                 | ConstExpr Literal
                 | CaseExpr [(PrimExpr,PrimExpr)] PrimExpr
@@ -80,22 +82,28 @@ data UnOp = OpNot
 data AggrOp     = AggrCount | AggrSum | AggrAvg | AggrMin | AggrMax
                 | AggrStdDev | AggrStdDevP | AggrVar | AggrVarP
                 | AggrBoolOr | AggrBoolAnd | AggrArr | JsonArr
-                | AggrStringAggr PrimExpr
+                | AggrStringAggr
                 | AggrOther String
                 deriving (Show,Read)
 
 data AggrDistinct = AggrDistinct | AggrAll
                   deriving (Eq,Show,Read)
 
-data Aggr
-  = GroupBy
-  | Aggr
-      { aggrOp :: !AggrOp
-      , aggrOrder :: ![OrderExpr]
-      , aggrDistinct :: !AggrDistinct
-      , aggrFilter :: !(Maybe PrimExpr)
-      }
-  deriving (Show, Read)
+type Aggregate = Aggregate' PrimExpr
+
+data Aggregate' a = GroupBy a | Aggregate (Aggr' a)
+  deriving (Functor, Foldable, Traversable, Show, Read)
+
+type Aggr = Aggr' PrimExpr
+
+data Aggr' a = Aggr
+  { aggrOp :: !AggrOp
+  , aggrExprs :: ![a]
+  , aggrOrder :: ![OrderExpr' a]
+  , aggrDistinct :: !AggrDistinct
+  , aggrFilter :: !(Maybe PrimExpr)
+  }
+  deriving (Functor, Foldable, Traversable, Show, Read)
 
 data OrderExpr = OrderExpr OrderOp PrimExpr
                deriving (Show,Read)
@@ -125,7 +133,7 @@ data WndwOp
   | WndwFirstValue PrimExpr
   | WndwLastValue PrimExpr
   | WndwNthValue PrimExpr PrimExpr
-  | WndwAggregate AggrOp PrimExpr
+  | WndwAggregate AggrOp [PrimExpr]
   deriving (Show,Read)
 
 data Partition = Partition

--- a/src/Opaleye/Internal/HaskellDB/Sql/Default.hs
+++ b/src/Opaleye/Internal/HaskellDB/Sql/Default.hs
@@ -2,6 +2,8 @@
 --                HWT Group (c) 2003, haskelldb-users@lists.sourceforge.net
 -- License     :  BSD-style
 
+{-# LANGUAGE LambdaCase #-}
+
 module Opaleye.Internal.HaskellDB.Sql.Default  where
 
 import Control.Applicative ((<$>))
@@ -130,13 +132,7 @@ defaultSqlExpr gen expr =
                                 UnOpFun     -> FunSqlExpr op' [e']
                                 UnOpPrefix  -> PrefixSqlExpr op' (ParensSqlExpr e')
                                 UnOpPostfix -> PostfixSqlExpr op' (ParensSqlExpr e')
-      -- TODO: The current arrangement whereby the delimiter parameter
-      -- of string_agg is in the AggrStringAggr constructor, but the
-      -- parameter being aggregated is not, seems unsatisfactory
-      -- because it leads to a non-uniformity of treatment, as seen
-      -- below.  Perhaps we should have just `AggrExpr AggrOp` and
-      -- always put the `PrimExpr` in the `AggrOp`.
-      AggrExpr distinct op e ord mfilter ->
+      AggrExpr (Aggr op e ord distinct mfilter) ->
         let
           (op', e') = showAggrOp gen op e
           ord' = toSqlOrder gen <$> ord
@@ -223,23 +219,27 @@ sqlUnOp  OpUpper       = ("UPPER", UnOpFun)
 sqlUnOp  (UnOpOther s) = (s, UnOpFun)
 
 
-showAggrOp :: SqlGenerator -> AggrOp -> PrimExpr -> (String, [SqlExpr])
-showAggrOp gen op arg = case op of
-  AggrCount -> ("COUNT", [sqlExpr gen arg])
-  AggrSum -> ("SUM", [sqlExpr gen arg])
-  AggrAvg -> ("AVG", [sqlExpr gen arg])
-  AggrMin -> ("MIN", [sqlExpr gen arg])
-  AggrMax -> ("MAX", [sqlExpr gen arg])
-  AggrStdDev -> ("StdDev", [sqlExpr gen arg])
-  AggrStdDevP -> ("StdDevP", [sqlExpr gen arg])
-  AggrVar -> ("Var", [sqlExpr gen arg])
-  AggrVarP -> ("VarP", [sqlExpr gen arg])
-  AggrBoolAnd -> ("BOOL_AND", [sqlExpr gen arg])
-  AggrBoolOr -> ("BOOL_OR", [sqlExpr gen arg])
-  AggrArr -> ("ARRAY_AGG", [sqlExpr gen arg])
-  JsonArr -> ("JSON_AGG", [sqlExpr gen arg])
-  AggrStringAggr sep -> ("STRING_AGG", [sqlExpr gen arg, sqlExpr gen sep])
-  AggrOther s -> (s, [sqlExpr gen arg])
+showAggrOp :: SqlGenerator -> AggrOp -> [PrimExpr] -> (String, [SqlExpr])
+showAggrOp gen op args = (showAggrOpFunction op, map (sqlExpr gen) args)
+
+
+showAggrOpFunction :: AggrOp -> String
+showAggrOpFunction = \case
+  AggrCount -> "COUNT"
+  AggrSum -> "SUM"
+  AggrAvg -> "AVG"
+  AggrMin -> "MIN"
+  AggrMax -> "MAX"
+  AggrStdDev -> "StdDev"
+  AggrStdDevP -> "StdDevP"
+  AggrVar -> "Var"
+  AggrVarP -> "VarP"
+  AggrBoolAnd -> "BOOL_AND"
+  AggrBoolOr -> "BOOL_OR"
+  AggrArr -> "ARRAY_AGG"
+  JsonArr -> "JSON_AGG"
+  AggrStringAggr -> "STRING_AGG"
+  AggrOther s -> s
 
 
 showWndwOp :: SqlGenerator -> WndwOp -> (String, [SqlExpr])
@@ -255,7 +255,7 @@ showWndwOp gen op = case op of
   WndwFirstValue e -> ("FIRST_VALUE", [sqlExpr gen e])
   WndwLastValue e -> ("LAST_VALUE", [sqlExpr gen e])
   WndwNthValue e n -> ("NTH_VALUE", map (sqlExpr gen) [e, n])
-  WndwAggregate op' arg -> showAggrOp gen op' arg
+  WndwAggregate op' args -> showAggrOp gen op' args
 
 
 defaultSqlLiteral :: SqlGenerator -> Literal -> String

--- a/src/Opaleye/Internal/PrimQuery.hs
+++ b/src/Opaleye/Internal/PrimQuery.hs
@@ -131,7 +131,7 @@ data PrimQuery' a = Unit
                   | Product   (NEL.NonEmpty (Lateral, PrimQuery' a)) [HPQ.PrimExpr]
                   -- | The subqueries to take the product of and the
                   --   restrictions to apply
-                  | Aggregate (Bindings (HPQ.Aggr, HPQ.Symbol))
+                  | Aggregate (Bindings (HPQ.Aggregate' HPQ.Symbol))
                               (PrimQuery' a)
                   | Window (Bindings (HPQ.WndwOp, HPQ.Partition)) (PrimQuery' a)
                   -- | Represents both @DISTINCT ON@ and @ORDER BY@
@@ -176,7 +176,7 @@ data PrimQueryFoldP a p p' = PrimQueryFold
   , empty             :: a -> p'
   , baseTable         :: TableIdentifier -> Bindings HPQ.PrimExpr -> p'
   , product           :: NEL.NonEmpty (Lateral, p) -> [HPQ.PrimExpr] -> p'
-  , aggregate         :: Bindings (HPQ.Aggr, HPQ.Symbol)
+  , aggregate         :: Bindings (HPQ.Aggregate' HPQ.Symbol)
                       -> p
                       -> p'
   , window            :: Bindings (HPQ.WndwOp, HPQ.Partition) -> p -> p'

--- a/src/Opaleye/Internal/Tag.hs
+++ b/src/Opaleye/Internal/Tag.hs
@@ -3,7 +3,7 @@ module Opaleye.Internal.Tag where
 import Control.Monad.Trans.State.Strict ( get, modify', State )
 
 -- | Tag is for use as a source of unique IDs in QueryArr
-newtype Tag = UnsafeTag Int deriving (Read, Show)
+newtype Tag = UnsafeTag Int deriving (Eq, Ord, Read, Show)
 
 start :: Tag
 start = UnsafeTag 1

--- a/src/Opaleye/Internal/Window.hs
+++ b/src/Opaleye/Internal/Window.hs
@@ -127,9 +127,9 @@ makeWndwAny op = lmap (const op) makeWndw
 -- argument to 'over').
 aggregatorWindowFunction :: A.Aggregator a b -> (a' -> a) -> WindowFunction a' b
 aggregatorWindowFunction agg g = WindowFunction $ PM.PackMap $ \f a ->
-  pm (\(mop, expr) -> case mop of
-         HPQ.GroupBy -> pure expr
-         HPQ.Aggr op _ _ _ -> f (HPQ.WndwAggregate op expr)) a
+  pm (\aggregate -> case aggregate of
+         HPQ.GroupBy expr -> pure expr
+         HPQ.Aggregate (HPQ.Aggr op exprs _ _ _) -> f (HPQ.WndwAggregate op exprs)) a
   where A.Aggregator (PM.PackMap pm) = lmap g agg
 
 


### PR DESCRIPTION
The first commit here refactors `Aggr` to include the `PrimExpr`s directly, and also gives it a `Traversable` instance allowing them to be replaced with `Symbol`s by `extractAggregateFields`. It also means `Aggr` can be used directly in `AggrExpr` which you had said you'd wanted to do before.

The next commit introduces a failing test demonstrating this bug.

And the final commit fixes this bug, making use of the refactoring done in the first commit. This does add `Eq` and `Ord` constraints to `PrimExpr`, which I think is fine, but if you found that distasteful an alternative would not to rewrite whole `PrimExpr`s in `extractAggregateFields`, but only the `AttrExprs` contained therein. Then you wouldn't need `Eq` and `Ord` for entire `PrimExpr`s, you'd only need to `Eq` and `Ord` for `Symbol` which is more conservative. You can see the comment added to `aggregateU` for more information on the implementation details.