### PR TITLE
Refactor `Aggr` to include the expressions it aggregates

### DIFF
--- a/src/Opaleye/Internal/HaskellDB/PrimQuery.hs
+++ b/src/Opaleye/Internal/HaskellDB/PrimQuery.hs
@@ -105,8 +105,10 @@ data Aggr' a = Aggr
   }
   deriving (Functor, Foldable, Traversable, Show, Read)
 
-data OrderExpr = OrderExpr OrderOp PrimExpr
-               deriving (Show,Read)
+type OrderExpr = OrderExpr' PrimExpr
+
+data OrderExpr' a = OrderExpr OrderOp a
+  deriving (Functor, Foldable, Traversable, Show, Read)
 
 data OrderNulls = NullsFirst | NullsLast
                 deriving (Show,Read)

--- a/src/Opaleye/Internal/HaskellDB/PrimQuery.hs
+++ b/src/Opaleye/Internal/HaskellDB/PrimQuery.hs
@@ -99,7 +99,7 @@ type Aggr = Aggr' PrimExpr
 data Aggr' a = Aggr
   { aggrOp :: !AggrOp
   , aggrExprs :: ![a]
-  , aggrOrder :: ![OrderExpr]
+  , aggrOrder :: ![OrderExpr' a]
   , aggrDistinct :: !AggrDistinct
   , aggrFilter :: !(Maybe PrimExpr)
   }

--- a/src/Opaleye/Internal/HaskellDB/Sql/Default.hs
+++ b/src/Opaleye/Internal/HaskellDB/Sql/Default.hs
@@ -2,6 +2,8 @@
 --                HWT Group (c) 2003, haskelldb-users@lists.sourceforge.net
 -- License     :  BSD-style
 
+{-# LANGUAGE LambdaCase #-}
+
 module Opaleye.Internal.HaskellDB.Sql.Default  where
 
 import Control.Applicative ((<$>))
@@ -130,13 +132,7 @@ defaultSqlExpr gen expr =
                                 UnOpFun     -> FunSqlExpr op' [e']
                                 UnOpPrefix  -> PrefixSqlExpr op' (ParensSqlExpr e')
                                 UnOpPostfix -> PostfixSqlExpr op' (ParensSqlExpr e')
-      -- TODO: The current arrangement whereby the delimiter parameter
-      -- of string_agg is in the AggrStringAggr constructor, but the
-      -- parameter being aggregated is not, seems unsatisfactory
-      -- because it leads to a non-uniformity of treatment, as seen
-      -- below.  Perhaps we should have just `AggrExpr AggrOp` and
-      -- always put the `PrimExpr` in the `AggrOp`.
-      AggrExpr distinct op e ord mfilter ->
+      AggrExpr (Aggr op e ord distinct mfilter) ->
         let
           (op', e') = showAggrOp gen op e
           ord' = toSqlOrder gen <$> ord
@@ -223,23 +219,27 @@ sqlUnOp  OpUpper       = ("UPPER", UnOpFun)
 sqlUnOp  (UnOpOther s) = (s, UnOpFun)
 
 
-showAggrOp :: SqlGenerator -> AggrOp -> PrimExpr -> (String, [SqlExpr])
-showAggrOp gen op arg = case op of
-  AggrCount -> ("COUNT", [sqlExpr gen arg])
-  AggrSum -> ("SUM", [sqlExpr gen arg])
-  AggrAvg -> ("AVG", [sqlExpr gen arg])
-  AggrMin -> ("MIN", [sqlExpr gen arg])
-  AggrMax -> ("MAX", [sqlExpr gen arg])
-  AggrStdDev -> ("StdDev", [sqlExpr gen arg])
-  AggrStdDevP -> ("StdDevP", [sqlExpr gen arg])
-  AggrVar -> ("Var", [sqlExpr gen arg])
-  AggrVarP -> ("VarP", [sqlExpr gen arg])
-  AggrBoolAnd -> ("BOOL_AND", [sqlExpr gen arg])
-  AggrBoolOr -> ("BOOL_OR", [sqlExpr gen arg])
-  AggrArr -> ("ARRAY_AGG", [sqlExpr gen arg])
-  JsonArr -> ("JSON_AGG", [sqlExpr gen arg])
-  AggrStringAggr sep -> ("STRING_AGG", [sqlExpr gen arg, sqlExpr gen sep])
-  AggrOther s -> (s, [sqlExpr gen arg])
+showAggrOp :: SqlGenerator -> AggrOp -> [PrimExpr] -> (String, [SqlExpr])
+showAggrOp gen op args = (showAggrOpFunction op, map (sqlExpr gen) args)
+
+
+showAggrOpFunction :: AggrOp -> String
+showAggrOpFunction = \case
+  AggrCount -> "COUNT"
+  AggrSum -> "SUM"
+  AggrAvg -> "AVG"
+  AggrMin -> "MIN"
+  AggrMax -> "MAX"
+  AggrStdDev -> "StdDev"
+  AggrStdDevP -> "StdDevP"
+  AggrVar -> "Var"
+  AggrVarP -> "VarP"
+  AggrBoolAnd -> "BOOL_AND"
+  AggrBoolOr -> "BOOL_OR"
+  AggrArr -> "ARRAY_AGG"
+  JsonArr -> "JSON_AGG"
+  AggrStringAggr -> "STRING_AGG"
+  AggrOther s -> s
 
 
 showWndwOp :: SqlGenerator -> WndwOp -> (String, [SqlExpr])
@@ -255,7 +255,7 @@ showWndwOp gen op = case op of
   WndwFirstValue e -> ("FIRST_VALUE", [sqlExpr gen e])
   WndwLastValue e -> ("LAST_VALUE", [sqlExpr gen e])
   WndwNthValue e n -> ("NTH_VALUE", map (sqlExpr gen) [e, n])
-  WndwAggregate op' arg -> showAggrOp gen op' arg
+  WndwAggregate op' args -> showAggrOp gen op' args
 
 
 defaultSqlLiteral :: SqlGenerator -> Literal -> String

--- a/src/Opaleye/Internal/PrimQuery.hs
+++ b/src/Opaleye/Internal/PrimQuery.hs
@@ -131,7 +131,7 @@ data PrimQuery' a = Unit
                   | Product   (NEL.NonEmpty (Lateral, PrimQuery' a)) [HPQ.PrimExpr]
                   -- | The subqueries to take the product of and the
                   --   restrictions to apply
-                  | Aggregate (Bindings (HPQ.Aggr, HPQ.Symbol))
+                  | Aggregate (Bindings (HPQ.Aggregate' HPQ.Symbol))
                               (PrimQuery' a)
                   | Window (Bindings (HPQ.WndwOp, HPQ.Partition)) (PrimQuery' a)
                   -- | Represents both @DISTINCT ON@ and @ORDER BY@
@@ -176,7 +176,7 @@ data PrimQueryFoldP a p p' = PrimQueryFold
   , empty             :: a -> p'
   , baseTable         :: TableIdentifier -> Bindings HPQ.PrimExpr -> p'
   , product           :: NEL.NonEmpty (Lateral, p) -> [HPQ.PrimExpr] -> p'
-  , aggregate         :: Bindings (HPQ.Aggr, HPQ.Symbol)
+  , aggregate         :: Bindings (HPQ.Aggregate' HPQ.Symbol)
                       -> p
                       -> p'
   , window            :: Bindings (HPQ.WndwOp, HPQ.Partition) -> p -> p'

--- a/src/Opaleye/Internal/Window.hs
+++ b/src/Opaleye/Internal/Window.hs
@@ -127,9 +127,9 @@ makeWndwAny op = lmap (const op) makeWndw
 -- argument to 'over').
 aggregatorWindowFunction :: A.Aggregator a b -> (a' -> a) -> WindowFunction a' b
 aggregatorWindowFunction agg g = WindowFunction $ PM.PackMap $ \f a ->
-  pm (\(mop, expr) -> case mop of
-         HPQ.GroupBy -> pure expr
-         HPQ.Aggr op _ _ _ -> f (HPQ.WndwAggregate op expr)) a
+  pm (\aggregate -> case aggregate of
+         HPQ.GroupBy expr -> pure expr
+         HPQ.Aggregate (HPQ.Aggr op exprs _ _ _) -> f (HPQ.WndwAggregate op exprs)) a
   where A.Aggregator (PM.PackMap pm) = lmap g agg
 
 


### PR DESCRIPTION
This PR makes several (hopefully uncontroversial) changes to Opaleye's internal data types for aggregation that are needed for followup work.

The first change basically changes:

```haskell
newtype Aggregator a b =
  Aggregator (PM.PackMap (HPQ.Aggr, HPQ.PrimExpr) HPQ.PrimExpr a b)

data PrimQuery' a = ...
                  | Aggregate (Bindings (HPQ.Aggr, HPQ.Symbol))
                              (PrimQuery' a)

data PrimExpr   = ...
                | AggrExpr  AggrDistinct AggrOp PrimExpr [OrderExpr] (Maybe PrimExpr)

data Aggr
  = GroupBy
  | Aggr
      { aggrOp :: !AggrOp
      , aggrOrder :: ![OrderExpr]
      , aggrDistinct :: !AggrDistinct
      , aggrFilter :: !(Maybe PrimExpr)
      }
  deriving (Show, Read)
```

to:

```haskell
newtype Aggregator a b =
  Aggregator (PM.PackMap HPQ.Aggregate HPQ.PrimExpr a b)

data PrimQuery' a = ...
                  | Aggregate (Bindings (HPQ.Aggregate' HPQ.Symbol))
                              (PrimQuery' a)

data PrimExpr   = ...
                | AggrExpr  Aggr

type Aggregate = Aggregate' PrimExpr

data Aggregate' a = GroupBy a | Aggregate (Aggr' a)
  deriving (Functor, Foldable, Traversable, Show, Read)

type Aggr = Aggr' PrimExpr

data Aggr' a = Aggr
  { aggrOp :: !AggrOp
  , aggrExprs :: ![a]
  , aggrOrder :: ![OrderExpr]
  , aggrDistinct :: !AggrDistinct
  , aggrFilter :: !(Maybe PrimExpr)
  }
  deriving (Functor, Foldable, Traversable, Show, Read)
```

In other words, taking the `PrimExpr`s that were carried by `Aggregator` alongside `Aggr` in a tuple and making them part of `Aggr` itself. This simplifies `Aggregator` and also allows the `Aggr` data structure to be reused by `PrimExpr`'s `AggrExpr`. The polymorphism given by `Aggreagte'` enables a `Traversable` instance which is used by `extractAggregateFields` to substitute `PrimExpr`s with `Symbol`s. It also fixes the weirdness with the parameter to `string_agg()` being part of the operator, and allows us to support aggregation functions that any number of arguments.

The next two commits take this further, by replacing:

```haskell
data Aggr' a = Aggr
  { ...
  , aggrOrder :: ![OrderExpr]
  , ...
  }
  deriving (Functor, Foldable, Traversable, Show, Read)

data OrderExpr = OrderExpr OrderOp PrimExpr
  deriving (Show, Read)
```

with

```haskell
data Aggr' a = Aggr
  { ...
  , aggrOrder :: ![OrderExpr' a]
  , ...
  }
  deriving (Functor, Foldable, Traversable, Show, Read)

type OrderExpr = OrderExpr' PrimExpr

data OrderExpr' a = OrderExpr OrderOp a
  deriving (Functor, Foldable, Traversable, Show, Read)
```

This makes it so that `extractAggregateFields`, by virtue of its use of the `Traversable` instance on `Aggregate`, rewrites the `PrimExpr`s in an `ORDER BY` clause of an aggregation function as well as the `PrimExpr`s passed as arguments to that function. Again, this doesn't accomplish anything in and of itself but it is needed for future work and is hopefully relatively uncontroversial on its own.