### PR TITLE
Add support for ordered-set aggregation functions (`WITHIN GROUP`)

### DIFF
--- a/src/Opaleye/Internal/HaskellDB/PrimQuery.hs
+++ b/src/Opaleye/Internal/HaskellDB/PrimQuery.hs
@@ -105,8 +105,10 @@ data Aggr' a = Aggr
   }
   deriving (Functor, Foldable, Traversable, Show, Read)
 
-data OrderExpr = OrderExpr OrderOp PrimExpr
-               deriving (Show,Read)
+type OrderExpr = OrderExpr' PrimExpr
+
+data OrderExpr' a = OrderExpr OrderOp a
+  deriving (Functor, Foldable, Traversable, Show, Read)
 
 data OrderNulls = NullsFirst | NullsLast
                 deriving (Show,Read)

--- a/src/Opaleye/Internal/HaskellDB/PrimQuery.hs
+++ b/src/Opaleye/Internal/HaskellDB/PrimQuery.hs
@@ -99,7 +99,7 @@ type Aggr = Aggr' PrimExpr
 data Aggr' a = Aggr
   { aggrOp :: !AggrOp
   , aggrExprs :: ![a]
-  , aggrOrder :: ![OrderExpr]
+  , aggrOrder :: ![OrderExpr' a]
   , aggrDistinct :: !AggrDistinct
   , aggrFilter :: !(Maybe PrimExpr)
   }

--- a/src/Opaleye/Internal/HaskellDB/PrimQuery.hs
+++ b/src/Opaleye/Internal/HaskellDB/PrimQuery.hs
@@ -101,6 +101,7 @@ data Aggr' a = Aggr
   , aggrExprs :: ![a]
   , aggrOrder :: ![OrderExpr' a]
   , aggrDistinct :: !AggrDistinct
+  , aggrGroup :: ![OrderExpr' a]
   , aggrFilter :: !(Maybe PrimExpr)
   }
   deriving (Functor, Foldable, Traversable, Show, Read)

--- a/src/Opaleye/Internal/HaskellDB/Sql.hs
+++ b/src/Opaleye/Internal/HaskellDB/Sql.hs
@@ -52,7 +52,7 @@ data SqlExpr = ColumnSqlExpr  SqlColumn
              | PrefixSqlExpr  String SqlExpr
              | PostfixSqlExpr String SqlExpr
              | FunSqlExpr     String [SqlExpr]
-             | AggrFunSqlExpr String [SqlExpr] [(SqlExpr, SqlOrder)] SqlDistinct (Maybe SqlExpr) -- ^ Aggregate functions separate from normal functions.
+             | AggrFunSqlExpr String [SqlExpr] [(SqlExpr, SqlOrder)] SqlDistinct [(SqlExpr, SqlOrder)] (Maybe SqlExpr) -- ^ Aggregate functions separate from normal functions.
              | WndwFunSqlExpr String [SqlExpr] SqlPartition
              | ConstSqlExpr   String
              | CaseSqlExpr    (NEL.NonEmpty (SqlExpr,SqlExpr)) SqlExpr

--- a/src/Opaleye/Internal/HaskellDB/Sql/Default.hs
+++ b/src/Opaleye/Internal/HaskellDB/Sql/Default.hs
@@ -132,15 +132,16 @@ defaultSqlExpr gen expr =
                                 UnOpFun     -> FunSqlExpr op' [e']
                                 UnOpPrefix  -> PrefixSqlExpr op' (ParensSqlExpr e')
                                 UnOpPostfix -> PostfixSqlExpr op' (ParensSqlExpr e')
-      AggrExpr (Aggr op e ord distinct mfilter) ->
+      AggrExpr (Aggr op e ord distinct group mfilter) ->
         let
           (op', e') = showAggrOp gen op e
           ord' = toSqlOrder gen <$> ord
           distinct' = case distinct of
             AggrDistinct -> SqlDistinct
             AggrAll      -> SqlNotDistinct
+          group' = toSqlOrder gen <$> group
           mfilter' = sqlExpr gen <$> mfilter
-         in AggrFunSqlExpr op' e' ord' distinct' mfilter'
+         in AggrFunSqlExpr op' e' ord' distinct' group' mfilter'
       WndwExpr op window  -> let (op', e') = showWndwOp gen op
                                  window' = toSqlPartition gen window
                               in WndwFunSqlExpr op' e' window'

--- a/src/Opaleye/Internal/HaskellDB/Sql/Default.hs
+++ b/src/Opaleye/Internal/HaskellDB/Sql/Default.hs
@@ -2,6 +2,8 @@
 --                HWT Group (c) 2003, haskelldb-users@lists.sourceforge.net
 -- License     :  BSD-style
 
+{-# LANGUAGE LambdaCase #-}
+
 module Opaleye.Internal.HaskellDB.Sql.Default  where
 
 import Control.Applicative ((<$>))
@@ -130,13 +132,7 @@ defaultSqlExpr gen expr =
                                 UnOpFun     -> FunSqlExpr op' [e']
                                 UnOpPrefix  -> PrefixSqlExpr op' (ParensSqlExpr e')
                                 UnOpPostfix -> PostfixSqlExpr op' (ParensSqlExpr e')
-      -- TODO: The current arrangement whereby the delimiter parameter
-      -- of string_agg is in the AggrStringAggr constructor, but the
-      -- parameter being aggregated is not, seems unsatisfactory
-      -- because it leads to a non-uniformity of treatment, as seen
-      -- below.  Perhaps we should have just `AggrExpr AggrOp` and
-      -- always put the `PrimExpr` in the `AggrOp`.
-      AggrExpr distinct op e ord mfilter ->
+      AggrExpr (Aggr op e ord distinct mfilter) ->
         let
           (op', e') = showAggrOp gen op e
           ord' = toSqlOrder gen <$> ord
@@ -223,23 +219,27 @@ sqlUnOp  OpUpper       = ("UPPER", UnOpFun)
 sqlUnOp  (UnOpOther s) = (s, UnOpFun)
 
 
-showAggrOp :: SqlGenerator -> AggrOp -> PrimExpr -> (String, [SqlExpr])
-showAggrOp gen op arg = case op of
-  AggrCount -> ("COUNT", [sqlExpr gen arg])
-  AggrSum -> ("SUM", [sqlExpr gen arg])
-  AggrAvg -> ("AVG", [sqlExpr gen arg])
-  AggrMin -> ("MIN", [sqlExpr gen arg])
-  AggrMax -> ("MAX", [sqlExpr gen arg])
-  AggrStdDev -> ("StdDev", [sqlExpr gen arg])
-  AggrStdDevP -> ("StdDevP", [sqlExpr gen arg])
-  AggrVar -> ("Var", [sqlExpr gen arg])
-  AggrVarP -> ("VarP", [sqlExpr gen arg])
-  AggrBoolAnd -> ("BOOL_AND", [sqlExpr gen arg])
-  AggrBoolOr -> ("BOOL_OR", [sqlExpr gen arg])
-  AggrArr -> ("ARRAY_AGG", [sqlExpr gen arg])
-  JsonArr -> ("JSON_AGG", [sqlExpr gen arg])
-  AggrStringAggr sep -> ("STRING_AGG", [sqlExpr gen arg, sqlExpr gen sep])
-  AggrOther s -> (s, [sqlExpr gen arg])
+showAggrOp :: SqlGenerator -> AggrOp -> [PrimExpr] -> (String, [SqlExpr])
+showAggrOp gen op args = (showAggrOpFunction op, map (sqlExpr gen) args)
+
+
+showAggrOpFunction :: AggrOp -> String
+showAggrOpFunction = \case
+  AggrCount -> "COUNT"
+  AggrSum -> "SUM"
+  AggrAvg -> "AVG"
+  AggrMin -> "MIN"
+  AggrMax -> "MAX"
+  AggrStdDev -> "StdDev"
+  AggrStdDevP -> "StdDevP"
+  AggrVar -> "Var"
+  AggrVarP -> "VarP"
+  AggrBoolAnd -> "BOOL_AND"
+  AggrBoolOr -> "BOOL_OR"
+  AggrArr -> "ARRAY_AGG"
+  JsonArr -> "JSON_AGG"
+  AggrStringAggr -> "STRING_AGG"
+  AggrOther s -> s
 
 
 showWndwOp :: SqlGenerator -> WndwOp -> (String, [SqlExpr])
@@ -255,7 +255,7 @@ showWndwOp gen op = case op of
   WndwFirstValue e -> ("FIRST_VALUE", [sqlExpr gen e])
   WndwLastValue e -> ("LAST_VALUE", [sqlExpr gen e])
   WndwNthValue e n -> ("NTH_VALUE", map (sqlExpr gen) [e, n])
-  WndwAggregate op' arg -> showAggrOp gen op' arg
+  WndwAggregate op' args -> showAggrOp gen op' args
 
 
 defaultSqlLiteral :: SqlGenerator -> Literal -> String

--- a/src/Opaleye/Internal/PrimQuery.hs
+++ b/src/Opaleye/Internal/PrimQuery.hs
@@ -131,7 +131,7 @@ data PrimQuery' a = Unit
                   | Product   (NEL.NonEmpty (Lateral, PrimQuery' a)) [HPQ.PrimExpr]
                   -- | The subqueries to take the product of and the
                   --   restrictions to apply
-                  | Aggregate (Bindings (HPQ.Aggr, HPQ.Symbol))
+                  | Aggregate (Bindings (HPQ.Aggregate' HPQ.Symbol))
                               (PrimQuery' a)
                   | Window (Bindings (HPQ.WndwOp, HPQ.Partition)) (PrimQuery' a)
                   -- | Represents both @DISTINCT ON@ and @ORDER BY@
@@ -176,7 +176,7 @@ data PrimQueryFoldP a p p' = PrimQueryFold
   , empty             :: a -> p'
   , baseTable         :: TableIdentifier -> Bindings HPQ.PrimExpr -> p'
   , product           :: NEL.NonEmpty (Lateral, p) -> [HPQ.PrimExpr] -> p'
-  , aggregate         :: Bindings (HPQ.Aggr, HPQ.Symbol)
+  , aggregate         :: Bindings (HPQ.Aggregate' HPQ.Symbol)
                       -> p
                       -> p'
   , window            :: Bindings (HPQ.WndwOp, HPQ.Partition) -> p -> p'

--- a/src/Opaleye/Internal/Window.hs
+++ b/src/Opaleye/Internal/Window.hs
@@ -129,9 +129,8 @@ aggregatorWindowFunction :: A.Aggregator a b -> (a' -> a) -> WindowFunction a' b
 aggregatorWindowFunction agg g = WindowFunction $ PM.PackMap $ \f a ->
   pm (\aggregate -> case aggregate of
          HPQ.GroupBy expr -> pure expr
-         HPQ.Aggregate (HPQ.Aggr op exprs _ _ _) -> f (HPQ.WndwAggregate op exprs)) a
+         HPQ.Aggregate (HPQ.Aggr op exprs _ _ _ _) -> f (HPQ.WndwAggregate op exprs)) a
   where A.Aggregator (PM.PackMap pm) = lmap g agg
-
 
 -- | 'over' applies a 'WindowFunction' on a particular 'Window'.  For
 -- example,

--- a/src/Opaleye/Internal/Window.hs
+++ b/src/Opaleye/Internal/Window.hs
@@ -127,9 +127,9 @@ makeWndwAny op = lmap (const op) makeWndw
 -- argument to 'over').
 aggregatorWindowFunction :: A.Aggregator a b -> (a' -> a) -> WindowFunction a' b
 aggregatorWindowFunction agg g = WindowFunction $ PM.PackMap $ \f a ->
-  pm (\(mop, expr) -> case mop of
-         HPQ.GroupBy -> pure expr
-         HPQ.Aggr op _ _ _ -> f (HPQ.WndwAggregate op expr)) a
+  pm (\aggregate -> case aggregate of
+         HPQ.GroupBy expr -> pure expr
+         HPQ.Aggregate (HPQ.Aggr op exprs _ _ _) -> f (HPQ.WndwAggregate op exprs)) a
   where A.Aggregator (PM.PackMap pm) = lmap g agg
 
 


### PR DESCRIPTION
This commit adds support for ordered-set aggregation functions such as `mode()` which use the `WITHIN GROUP (ORDER BY _)` syntax. However, it doesn't actually expose any public facing API for this, basically because I don't know yet what that API should be for Opaleye. There are a lot of subtle restrictions on the kinds of arguments you can pass to the ordered-set aggregation functions (e.g., `percentile_disc()` can take either a constant expression or one of the columns from the query we're aggregating over, but only if it's part of the `GROUP BY` clause) that would be hard to capture in the types that Opaleye currently uses.

What this commit does is add just enough internals for me to able to experiment with a limited API in Rel8 for ordered-set aggregation functions that might be subject to change in the future. But I don't want to add something half-baked to Opaleye's public facing API just yet.