### PR TITLE
Add support for `WITH _ AS MATERIALIZED (_)` queries

### DIFF
--- a/src/Opaleye/Internal/Optimize.hs
+++ b/src/Opaleye/Internal/Optimize.hs
@@ -72,7 +72,7 @@ removeEmpty = PQ.foldPrimQuery PQ.PrimQueryFold {
   , PQ.relExpr   = return .: PQ.RelExpr
   , PQ.rebind    = \b -> fmap . PQ.Rebind b
   , PQ.forUpdate = fmap PQ.ForUpdate
-  , PQ.with      = \recursive name cols -> liftA2 (PQ.With recursive name cols)
+  , PQ.with      = \recursive materialized name cols -> liftA2 (PQ.With recursive materialized name cols)
   }
   where -- If only the first argument is Just, do n1 on it
         -- If only the second argument is Just, do n2 on it

--- a/src/Opaleye/Internal/PrimQuery.hs
+++ b/src/Opaleye/Internal/PrimQuery.hs
@@ -49,6 +49,9 @@ instance Monoid Lateral where
 data Recursive = NonRecursive | Recursive
   deriving Show
 
+data Materialized = Materialized | NotMaterialized
+  deriving Show
+
 aLeftJoin :: HPQ.PrimExpr -> PrimQuery -> PrimQueryArr
 aLeftJoin cond primQuery' = PrimQueryArr $ \lat primQueryL ->
   Join LeftJoin cond (NonLateral, primQueryL) (lat, primQuery')
@@ -162,7 +165,7 @@ data PrimQuery' a = Unit
                   -- ForUpdate in the future
                   --
                   -- https://www.postgresql.org/docs/current/sql-select.html#SQL-FOR-UPDATE-SHARE
-                  | With Recursive Symbol [Symbol] (PrimQuery' a) (PrimQuery' a)
+                  | With Recursive (Maybe Materialized) Symbol [Symbol] (PrimQuery' a) (PrimQuery' a)
                  deriving Show
 
 type PrimQuery = PrimQuery' ()
@@ -200,7 +203,7 @@ data PrimQueryFoldP a p p' = PrimQueryFold
     -- ^ A relation-valued expression
   , rebind            :: Bool -> Bindings HPQ.PrimExpr -> p -> p'
   , forUpdate         :: p -> p'
-  , with              :: Recursive -> Symbol -> [Symbol] -> p -> p -> p'
+  , with              :: Recursive -> Maybe Materialized -> Symbol -> [Symbol] -> p -> p -> p'
   }
 
 
@@ -248,7 +251,7 @@ dimapPrimQueryFold self g f = PrimQueryFold
   , relExpr = \pe bs -> g (relExpr f pe bs)
   , rebind = \s bs p -> g (rebind f s bs (self p))
   , forUpdate = \p -> g (forUpdate f (self p))
-  , with = \r s ss p1 p2 -> g (with f r s ss (self p1) (self p2))
+  , with = \r m s ss p1 p2 -> g (with f r m s ss (self p1) (self p2))
   }
 
 applyPrimQueryFoldF ::
@@ -271,7 +274,7 @@ applyPrimQueryFoldF f = \case
   Exists s q -> exists f s q
   Rebind star pes q -> rebind f star pes q
   ForUpdate q -> forUpdate f q
-  With recursive name cols a b -> with f recursive name cols a b
+  With recursive materialized name cols a b -> with f recursive materialized name cols a b
 
 primQueryFoldF ::
   PrimQueryFoldP a p p' -> (PrimQuery' a -> p) -> PrimQuery' a -> p'

--- a/src/Opaleye/Internal/Print.hs
+++ b/src/Opaleye/Internal/Print.hs
@@ -126,12 +126,17 @@ ppRecursive :: Sql.Recursive -> Doc
 ppRecursive Sql.Recursive = text "RECURSIVE"
 ppRecursive Sql.NonRecursive = mempty
 
+ppMaterialized :: Sql.Materialized -> Doc
+ppMaterialized Sql.Materialized = text "MATERIALIZED"
+ppMaterialized Sql.NotMaterialized = text "NOT MATERIALIZED"
+
 ppWith :: With -> Doc
 ppWith w
   =  text "WITH" <+> ppRecursive (Sql.wRecursive w)
   <+> HPrint.ppTable (Sql.wTable w)
   <+> parens (HPrint.commaV unColumn (Sql.wCols w))
   <+> text "AS"
+  <+> foldMap ppMaterialized (Sql.wMaterialized w)
   $$ parens (ppSql (Sql.wWith w))
   $$ ppSql (Sql.wSelect w)
   where unColumn (HSql.SqlColumn col) = text col


### PR DESCRIPTION
Before PostgreSQL 12, `WITH` was always materialized, but since PostgreSQL 12 this is not necessarily the case (it's up to the query planner).

However, a new syntax was added for explicitly specifying whether a `WITH` query should be `MATERIALIZED` or `NOT MATERIALIZED`. This commit adds support for this to Opaleye's core, and adds the function `withMaterialized` to the user-facing API.