### PR TITLE
IsSqlType instance is needed if the field is an array of enum

### DIFF
--- a/src/Opaleye/Experimental/Enum.hs
+++ b/src/Opaleye/Experimental/Enum.hs
@@ -83,6 +83,9 @@ data EnumMapper sqlEnum haskellSum = EnumMapper {
 --
 -- instance D.Default O.ToFields Rating (O.Field SqlRating) where
 --   def = enumToFields sqlRatingMapper
+--
+-- instance IsSqlType SqlRating where
+--   showSqlType _ = "mpaa_rating"
 -- @
 enumMapper :: String
            -- ^ The name of the @ENUM@ type


### PR DESCRIPTION
when toFields is used on sql array, it uses this instance

```
(Default ToFields a (Field_ n b), IsSqlType b) => Default ToFields [a] (Field (SqlArray_ n b))
```

Which cast the value to the enum type