### PR TITLE
Add `Eq` and `Ord` instances for `TableIdentifier`

### DIFF
--- a/src/Opaleye/Internal/PrimQuery.hs
+++ b/src/Opaleye/Internal/PrimQuery.hs
@@ -29,7 +29,7 @@ data SemijoinType = Semi | Anti deriving Show
 data TableIdentifier = TableIdentifier
   { tiSchemaName :: Maybe String
   , tiTableName  :: String
-  } deriving Show
+  } deriving (Show, Eq, Ord)
 
 tiToSqlTable :: TableIdentifier -> HSql.SqlTable
 tiToSqlTable ti = HSql.SqlTable { HSql.sqlTableSchemaName = tiSchemaName ti


### PR DESCRIPTION
Tiny PR adding an `Ord` instance to `TableIdentifier` so that I can use it as a key in a `Map` in [effectful-opaleye](https://github.com/fpringle/effectful-postgresql/tree/main/effectful-opaleye).

I understand there's an argument to be made against the `Eq`, since there's a context in which `schema.table` and `table` might be considered equal, despite not comparing equal as Haskell values. If this is an issue, I'd be happy to swap the instances out for a `Hashable` instance (the `hashable` package is already a transitive dependency, so it wouldn't add to the footprint).