### PR TITLE
Add AnyExpr for ANY expressions

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2014-2018 Purely Agile Limited; 2019-2025 Tom Ellis
+Copyright (c) 2014-2018 Purely Agile Limited; 2019-2026 Tom Ellis
 
 All rights reserved.
 

--- a/Test/Test.hs
+++ b/Test/Test.hs
@@ -1134,6 +1134,15 @@ testSqlElem = do
     testH (A.pure (O.sqlElem 999 (O.sqlArray O.sqlInt4 [5,6,7])))
           (`shouldBe` [False])
 
+testSqlElemAny :: Test
+testSqlElemAny = do
+  it "checks presence of the element (SqlInt4)" $
+    testH (A.pure (O.sqlElemAny 5 (O.sqlArray O.sqlInt4 [5,6,7])))
+          (`shouldBe` [True])
+  it "checks absence of the element (SqlInt4)" $
+    testH (A.pure (O.sqlElemAny 999 (O.sqlArray O.sqlInt4 [5,6,7])))
+          (`shouldBe` [False])
+
 type JsonTest a = SpecWith (Select (Field a) -> PGS.Connection -> Expectation)
 -- Test opaleye's equivalent of c1->'c'
 testJsonGetFieldValue :: (O.SqlIsJson a, DefaultFromField a Json.Value)
@@ -1658,6 +1667,7 @@ main = do
         testArrayAppend
         testArrayPosition
         testSqlElem
+        testSqlElemAny
       describe "joins" $ do
         testLeftJoin
         testLeftJoinNullable

--- a/opaleye.cabal
+++ b/opaleye.cabal
@@ -1,5 +1,5 @@
 name:            opaleye
-copyright:       Copyright (c) 2014-2018 Purely Agile Limited; 2019-2025 Tom Ellis
+copyright:       Copyright (c) 2014-2018 Purely Agile Limited; 2019-2026 Tom Ellis
 version:         0.10.7.0
 synopsis:        An SQL-generating DSL targeting PostgreSQL
 description:     An SQL-generating DSL targeting PostgreSQL.  Allows

--- a/src/Opaleye/Internal/HaskellDB/PrimQuery.hs
+++ b/src/Opaleye/Internal/HaskellDB/PrimQuery.hs
@@ -23,6 +23,7 @@ data PrimExpr   = AttrExpr  Symbol
                 | BaseTableAttrExpr Attribute
                 | CompositeExpr     PrimExpr Attribute -- ^ Composite Type Query
                 | BinExpr   BinOp PrimExpr PrimExpr
+                | AnyExpr   BinOp PrimExpr PrimExpr -- ^ <expr> = <op> ANY(<expr>)
                 | UnExpr    UnOp PrimExpr
                 | AggrExpr  (Aggr' PrimExpr)
                 | WndwExpr  WndwOp Partition

--- a/src/Opaleye/Internal/HaskellDB/PrimQuery.hs
+++ b/src/Opaleye/Internal/HaskellDB/PrimQuery.hs
@@ -23,7 +23,7 @@ data PrimExpr   = AttrExpr  Symbol
                 | BaseTableAttrExpr Attribute
                 | CompositeExpr     PrimExpr Attribute -- ^ Composite Type Query
                 | BinExpr   BinOp PrimExpr PrimExpr
-                | AnyExpr   BinOp PrimExpr PrimExpr -- ^ <expr> = <op> ANY(<expr>)
+                | AnyExpr   BinOp PrimExpr PrimExpr -- ^ <expr> <op> ANY(<expr>)
                 | UnExpr    UnOp PrimExpr
                 | AggrExpr  (Aggr' PrimExpr)
                 | WndwExpr  WndwOp Partition

--- a/src/Opaleye/Internal/HaskellDB/Sql.hs
+++ b/src/Opaleye/Internal/HaskellDB/Sql.hs
@@ -48,6 +48,7 @@ data SqlDistinct = SqlDistinct | SqlNotDistinct
 data SqlExpr = ColumnSqlExpr  SqlColumn
              | CompositeSqlExpr SqlExpr String
              | BinSqlExpr     String SqlExpr SqlExpr
+             | AnySqlExpr     String SqlExpr SqlExpr
              | SubscriptSqlExpr SqlExpr SqlExpr
              | PrefixSqlExpr  String SqlExpr
              | PostfixSqlExpr String SqlExpr

--- a/src/Opaleye/Internal/HaskellDB/Sql/Default.hs
+++ b/src/Opaleye/Internal/HaskellDB/Sql/Default.hs
@@ -124,6 +124,10 @@ defaultSqlExpr gen expr =
                 (leftE, paren rightE)
               _ -> (paren leftE, paren rightE)
         in BinSqlExpr (showBinOp op) expL expR
+      AnyExpr op e1 e2 ->
+        let leftE = sqlExpr gen e1
+            rightE = sqlExpr gen e2
+        in AnySqlExpr (showBinOp op) (ParensSqlExpr leftE) rightE 
       UnExpr op e      -> let (op',t) = sqlUnOp op
                               e' = sqlExpr gen e
                            in case t of

--- a/src/Opaleye/Internal/HaskellDB/Sql/Default.hs
+++ b/src/Opaleye/Internal/HaskellDB/Sql/Default.hs
@@ -127,7 +127,7 @@ defaultSqlExpr gen expr =
       AnyExpr op e1 e2 ->
         let leftE = sqlExpr gen e1
             rightE = sqlExpr gen e2
-        in AnySqlExpr (showBinOp op) (ParensSqlExpr leftE) rightE 
+        in AnySqlExpr (showBinOp op) (ParensSqlExpr leftE) rightE
       UnExpr op e      -> let (op',t) = sqlUnOp op
                               e' = sqlExpr gen e
                            in case t of

--- a/src/Opaleye/Internal/HaskellDB/Sql/Print.hs
+++ b/src/Opaleye/Internal/HaskellDB/Sql/Print.hs
@@ -181,6 +181,7 @@ ppSqlExpr expr =
       ParensSqlExpr e        -> parens (ppSqlExpr e)
       SubscriptSqlExpr e1 e2 -> ppSqlExpr e1 <> brackets (ppSqlExpr e2)
       BinSqlExpr op e1 e2    -> ppSqlExpr e1 <+> text op <+> ppSqlExpr e2
+      AnySqlExpr op e1 e2    -> ppSqlExpr e1 <+> text op <+> text "ANY" <+> parens (ppSqlExpr e2)
       PrefixSqlExpr op e     -> text op <+> ppSqlExpr e
       PostfixSqlExpr op e    -> ppSqlExpr e <+> text op
       FunSqlExpr f es        -> text f <> parens (commaH ppSqlExpr es)

--- a/src/Opaleye/Operators.hs
+++ b/src/Opaleye/Operators.hs
@@ -437,12 +437,10 @@ arrayPosition (Column fs) (Column f') =
   C.Column (HPQ.FunExpr "array_position" [fs , f'])
 
 -- | Whether the element (needle) exists in the array (haystack).
--- N.B. this is implemented hackily using @array_position@.  If you
--- need it to be implemented using @= any@ then please open an issue.
 sqlElem :: F.Field_ n a -- ^ Needle
         -> F.Field (T.SqlArray_ n a) -- ^ Haystack
         -> F.Field T.SqlBool
-sqlElem f fs = (O.not . F.isNull . arrayPosition fs) f
+sqlElem (Column f) (Column fs) = Column $ HPQ.AnyExpr (HPQ.:==) f fs
 
 overlap :: Field (T.SqlRange a) -> Field (T.SqlRange a) -> F.Field T.SqlBool
 overlap = C.binOp (HPQ.:&&)

--- a/src/Opaleye/Operators.hs
+++ b/src/Opaleye/Operators.hs
@@ -86,6 +86,7 @@ module Opaleye.Operators
   , index
   , arrayPosition
   , sqlElem
+  , sqlElemAny
   -- * Range operators
   , overlap
   , liesWithin
@@ -443,6 +444,13 @@ sqlElem :: F.Field_ n a -- ^ Needle
         -> F.Field (T.SqlArray_ n a) -- ^ Haystack
         -> F.Field T.SqlBool
 sqlElem f fs = (O.not . F.isNull . arrayPosition fs) f
+
+-- | Whether the element (needle) exists in the array (haystack).
+-- This is implemented using @= any@.
+sqlElemAny :: F.Field_ n a -- ^ Needle
+           -> F.Field (T.SqlArray_ n a) -- ^ Haystack
+           -> F.Field T.SqlBool
+sqlElemAny (Column f) (Column fs) = Column $ HPQ.AnyExpr (HPQ.:==) f fs
 
 overlap :: Field (T.SqlRange a) -> Field (T.SqlRange a) -> F.Field T.SqlBool
 overlap = C.binOp (HPQ.:&&)

--- a/src/Opaleye/Operators.hs
+++ b/src/Opaleye/Operators.hs
@@ -437,10 +437,12 @@ arrayPosition (Column fs) (Column f') =
   C.Column (HPQ.FunExpr "array_position" [fs , f'])
 
 -- | Whether the element (needle) exists in the array (haystack).
+-- N.B. this is implemented hackily using @array_position@.  If you
+-- need it to be implemented using @= any@ then please open an issue.
 sqlElem :: F.Field_ n a -- ^ Needle
         -> F.Field (T.SqlArray_ n a) -- ^ Haystack
         -> F.Field T.SqlBool
-sqlElem (Column f) (Column fs) = Column $ HPQ.AnyExpr (HPQ.:==) f fs
+sqlElem f fs = (O.not . F.isNull . arrayPosition fs) f
 
 overlap :: Field (T.SqlRange a) -> Field (T.SqlRange a) -> F.Field T.SqlBool
 overlap = C.binOp (HPQ.:&&)


### PR DESCRIPTION
Heya, I've come across a need for `<expr> = ANY(...)` support due to the postgres version I'm using not being smart enough to use an index when the [`array_position` implementation](https://github.com/tomjaguarpaw/haskell-opaleye/blob/74c1f9db2a152b077f39668b265c015a48888bb4/src/Opaleye/Operators.hs#L445) of `sqlElem` is used.

I'm not sure if this is the correct solution to implementing it (but I think it is as `<op> ANY(...)` seems to be a special form in (postgres?)sql too)

I've been using this patch privately for a month or so now. 