### PR TITLE
Add ON CONFLICT DO UPDATE SET support (doUpdate, doUpdateEasy, doUpdateAll)

### DIFF
--- a/Test/Test.hs
+++ b/Test/Test.hs
@@ -1045,10 +1045,10 @@ testInsertConflict = it "inserts with conflicts" $ \conn -> do
 
         runSelectTable10 conn = O.runSelect conn (O.selectTable table10)
 
--- Helper shared by the three doUpdate tests: inserts initial rows,
--- runs an upsert with the given conflict action, then checks the result.
-runUpsertTest :: O.OnConflict -> PGS.Connection -> IO ()
-runUpsertTest onConflict conn = do
+-- Helper shared by the doUpdate tests: inserts initial rows, runs an
+-- upsert with the given conflict action, then checks the result.
+runUpsertTest :: O.OnConflict -> [UpsertRow' Int Int] -> PGS.Connection -> IO ()
+runUpsertTest onConflict expected conn = do
   _ <- O.runDelete_ conn O.Delete { O.dTable     = upsertTable
                                   , O.dWhere     = const (O.toFields True)
                                   , O.dReturning = O.rCount }
@@ -1061,27 +1061,48 @@ runUpsertTest onConflict conn = do
                                   , O.iReturning  = O.rCount
                                   , O.iOnConflict = Just onConflict }
   rows <- O.runSelect conn (O.selectTable upsertTable) :: IO [UpsertRow' Int Int]
-  L.sort rows `shouldBe` [ UpsertRow 1 99
-                          , UpsertRow 2 20
-                          , UpsertRow 3 30 ]
+  L.sort rows `shouldBe` expected
   where
     initial  = [UpsertRow 1 10, UpsertRow 2 20] :: [UpsertRowFields]
     upserted = [UpsertRow 1 99, UpsertRow 3 30] :: [UpsertRowFields]
+
+replacedRows :: [UpsertRow' Int Int]
+replacedRows = [UpsertRow 1 99, UpsertRow 2 20, UpsertRow 3 30]
 
 testDoUpdate :: Test
 testDoUpdate = it "doUpdate replaces conflicting rows using excluded values" $
   runUpsertTest
     (O.doUpdate upsertTable upsertKey
-      (\excl -> UpsertRow { upsertKey = upsertKey excl
-                          , upsertVal = upsertVal excl }))
+      (\_ excluded -> UpsertRow { upsertKey = upsertKey excluded
+                                , upsertVal = upsertVal excluded }))
+    replacedRows
+
+testDoUpdateExisting :: Test
+testDoUpdateExisting = it "doUpdate can refer to the existing row" $
+  runUpsertTest
+    (O.doUpdate upsertTable upsertKey
+      (\existing excluded ->
+         UpsertRow { upsertKey = upsertKey excluded
+                   , upsertVal = upsertVal existing + upsertVal excluded }))
+    -- Row 1 accumulates 10 + 99; row 3 is a plain insert, so no
+    -- existing row is involved.
+    [UpsertRow 1 109, UpsertRow 2 20, UpsertRow 3 30]
 
 testDoUpdateEasy :: Test
 testDoUpdateEasy = it "doUpdateEasy replaces conflicting rows without needing write-type wrappers" $
-  runUpsertTest (O.doUpdateEasy upsertTable upsertKey id)
+  runUpsertTest (O.doUpdateEasy upsertTable upsertKey (\_ excluded -> excluded))
+                replacedRows
+
+testDoUpdateEasyExisting :: Test
+testDoUpdateEasyExisting = it "doUpdateEasy leaves unmentioned columns at their existing values" $
+  runUpsertTest
+    (O.doUpdateEasy upsertTable upsertKey (\existing _ -> existing))
+    -- Row 1 keeps its existing value of 10.
+    [UpsertRow 1 10, UpsertRow 2 20, UpsertRow 3 30]
 
 testDoUpdateAll :: Test
 testDoUpdateAll = it "doUpdateAll replaces all columns of conflicting rows" $
-  runUpsertTest (O.doUpdateAll upsertTable upsertKey)
+  runUpsertTest (O.doUpdateAll upsertTable upsertKey) replacedRows
 
 testKeywordColNames :: Test
 testKeywordColNames = it "" $ \conn -> do
@@ -1755,7 +1776,9 @@ main = do
         testDeleteReturning
         testInsertConflict
         testDoUpdate
+        testDoUpdateExisting
         testDoUpdateEasy
+        testDoUpdateEasyExisting
         testDoUpdateAll
         testSelectCaseNull
       describe "range" $ do

--- a/Test/Test.hs
+++ b/Test/Test.hs
@@ -169,6 +169,12 @@ upsertTable = O.table "table11" $ pUpsertRow UpsertRow
   , upsertVal = required "column2"
   }
 
+-- table12's unique index is on lower(column1) rather than on a column,
+-- so upserting into it exercises an expression conflict target.
+exprIndexTable :: O.Table (Field O.SqlText, Field O.SqlInt4)
+                          (Field O.SqlText, Field O.SqlInt4)
+exprIndexTable = O.table "table12" (PP.p2 (required "column1", required "column2"))
+
 tableKeywordColNames :: O.Table (Field O.SqlInt4, Field O.SqlInt4)
                                 (Field O.SqlInt4, Field O.SqlInt4)
 tableKeywordColNames = O.table "keywordtable"
@@ -331,6 +337,15 @@ jsonbTables = [("table9", ["column1"])]
 conflictTables :: [Table_]
 conflictTables = [("table10", ["column1"]), ("table11", ["column1", "column2"])]
 
+-- Unlike the other conflict tables, table12's uniqueness comes from an
+-- expression index rather than a primary key.
+dropAndCreateTableExprIndex :: PGS.Query
+dropAndCreateTableExprIndex =
+  "DROP TABLE IF EXISTS \"public\".\"table12\";\
+  \CREATE TABLE \"public\".\"table12\"\
+  \ (\"column1\" text, \"column2\" integer);\
+  \CREATE UNIQUE INDEX ON \"public\".\"table12\" (lower(\"column1\"));"
+
 dropAndCreateDB :: PGS.Connection -> IO ()
 dropAndCreateDB conn = do
   mapM_ execute tables
@@ -338,6 +353,7 @@ dropAndCreateDB conn = do
   mapM_ executeSerial serialTables
   mapM_ executeJson jsonTables
   mapM_ executeConflict conflictTables
+  _ <- PGS.execute_ conn dropAndCreateTableExprIndex
   mapM_ executeJsonb jsonbTables
   where execute = PGS.execute_ conn . dropAndCreateTableInt
         executeTextTable = PGS.execute_ conn . dropAndCreateTableText
@@ -1104,6 +1120,29 @@ testDoUpdateAll :: Test
 testDoUpdateAll = it "doUpdateAll replaces all columns of conflicting rows" $
   runUpsertTest (O.doUpdateAll upsertTable upsertKey) replacedRows
 
+testDoUpdateExprTarget :: Test
+testDoUpdateExprTarget = it "doUpdate can conflict on an expression index" $ \conn -> do
+  _ <- O.runDelete_ conn O.Delete { O.dTable     = exprIndexTable
+                                  , O.dWhere     = const (O.toFields True)
+                                  , O.dReturning = O.rCount }
+  _ <- O.runInsert_ conn O.Insert { O.iTable      = exprIndexTable
+                                  , O.iRows       = [O.toFields ("Foo" :: String, 10 :: Int)]
+                                  , O.iReturning  = O.rCount
+                                  , O.iOnConflict = Nothing }
+  -- "FOO" conflicts with "Foo" only via the lower(column1) index.
+  _ <- O.runInsert_ conn O.Insert { O.iTable      = exprIndexTable
+                                  , O.iRows       = [O.toFields ("FOO" :: String, 5 :: Int)]
+                                  , O.iReturning  = O.rCount
+                                  , O.iOnConflict = Just conflictAction }
+  rows <- O.runSelect conn (O.selectTable exprIndexTable) :: IO [(String, Int)]
+  rows `shouldBe` [("Foo", 15)]
+  where
+    -- Keeps the existing "Foo" rather than taking excluded's "FOO".
+    conflictAction =
+      O.doUpdateEasy exprIndexTable (\(c1, _) -> O.lower c1)
+        (\(existingKey, existingVal) (_, excludedVal) ->
+           (existingKey, existingVal + excludedVal))
+
 testKeywordColNames :: Test
 testKeywordColNames = it "" $ \conn -> do
   let q :: IO [(Int, Int)]
@@ -1780,6 +1819,7 @@ main = do
         testDoUpdateEasy
         testDoUpdateEasyExisting
         testDoUpdateAll
+        testDoUpdateExprTarget
         testSelectCaseNull
       describe "range" $ do
         testRangeOverlap

--- a/Test/Test.hs
+++ b/Test/Test.hs
@@ -1,7 +1,10 @@
-{-# LANGUAGE Arrows              #-}
-{-# LANGUAGE FlexibleContexts    #-}
-{-# LANGUAGE OverloadedStrings   #-}
-{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE Arrows                #-}
+{-# LANGUAGE FlexibleContexts      #-}
+{-# LANGUAGE FlexibleInstances     #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE OverloadedStrings     #-}
+{-# LANGUAGE ScopedTypeVariables   #-}
+{-# LANGUAGE TemplateHaskell       #-}
 
 module Main where
 
@@ -20,6 +23,7 @@ import qualified Data.Ord                         as Ord
 import qualified Data.Profunctor                  as P
 import qualified Data.Profunctor.Product          as PP
 import qualified Data.Profunctor.Product.Default  as D
+import           Data.Profunctor.Product.TH       (makeAdaptorAndInstance)
 import qualified Data.String                      as String
 import qualified Data.ByteString                  as SBS
 import qualified Data.Text                        as T
@@ -145,6 +149,25 @@ table9 = O.table "table9" (required "column1")
 
 table10 :: O.Table (Field O.SqlInt4) (Field O.SqlInt4)
 table10 = O.table "table10" (required "column1")
+
+table11 :: O.Table (Field O.SqlInt4, Field O.SqlInt4)
+                   (Field O.SqlInt4, Field O.SqlInt4)
+table11 = O.table "table11" (PP.p2 (required "column1", required "column2"))
+
+data UpsertRow' a b = UpsertRow
+  { upsertKey :: a
+  , upsertVal :: b
+  } deriving (Show, Eq, Ord)
+
+$(makeAdaptorAndInstance "pUpsertRow" ''UpsertRow')
+
+type UpsertRowFields = UpsertRow' (Field O.SqlInt4) (Field O.SqlInt4)
+
+upsertTable :: O.Table UpsertRowFields UpsertRowFields
+upsertTable = O.table "table11" $ pUpsertRow UpsertRow
+  { upsertKey = required "column1"
+  , upsertVal = required "column2"
+  }
 
 tableKeywordColNames :: O.Table (Field O.SqlInt4, Field O.SqlInt4)
                                 (Field O.SqlInt4, Field O.SqlInt4)
@@ -306,7 +329,7 @@ jsonbTables :: [Table_]
 jsonbTables = [("table9", ["column1"])]
 
 conflictTables :: [Table_]
-conflictTables = [("table10", ["column1"])]
+conflictTables = [("table10", ["column1"]), ("table11", ["column1", "column2"])]
 
 dropAndCreateDB :: PGS.Connection -> IO ()
 dropAndCreateDB conn = do
@@ -1022,6 +1045,44 @@ testInsertConflict = it "inserts with conflicts" $ \conn -> do
 
         runSelectTable10 conn = O.runSelect conn (O.selectTable table10)
 
+-- Helper shared by the three doUpdate tests: inserts initial rows,
+-- runs an upsert with the given conflict action, then checks the result.
+runUpsertTest :: O.OnConflict -> PGS.Connection -> IO ()
+runUpsertTest onConflict conn = do
+  _ <- O.runDelete_ conn O.Delete { O.dTable     = upsertTable
+                                  , O.dWhere     = const (O.toFields True)
+                                  , O.dReturning = O.rCount }
+  _ <- O.runInsert_ conn O.Insert { O.iTable      = upsertTable
+                                  , O.iRows       = initial
+                                  , O.iReturning  = O.rCount
+                                  , O.iOnConflict = Nothing }
+  _ <- O.runInsert_ conn O.Insert { O.iTable      = upsertTable
+                                  , O.iRows       = upserted
+                                  , O.iReturning  = O.rCount
+                                  , O.iOnConflict = Just onConflict }
+  rows <- O.runSelect conn (O.selectTable upsertTable) :: IO [UpsertRow' Int Int]
+  L.sort rows `shouldBe` [ UpsertRow 1 99
+                          , UpsertRow 2 20
+                          , UpsertRow 3 30 ]
+  where
+    initial  = [UpsertRow 1 10, UpsertRow 2 20] :: [UpsertRowFields]
+    upserted = [UpsertRow 1 99, UpsertRow 3 30] :: [UpsertRowFields]
+
+testDoUpdate :: Test
+testDoUpdate = it "doUpdate replaces conflicting rows using excluded values" $
+  runUpsertTest
+    (O.doUpdate upsertTable upsertKey
+      (\excl -> UpsertRow { upsertKey = upsertKey excl
+                          , upsertVal = upsertVal excl }))
+
+testDoUpdateEasy :: Test
+testDoUpdateEasy = it "doUpdateEasy replaces conflicting rows without needing write-type wrappers" $
+  runUpsertTest (O.doUpdateEasy upsertTable upsertKey id)
+
+testDoUpdateAll :: Test
+testDoUpdateAll = it "doUpdateAll replaces all columns of conflicting rows" $
+  runUpsertTest (O.doUpdateAll upsertTable upsertKey)
+
 testKeywordColNames :: Test
 testKeywordColNames = it "" $ \conn -> do
   let q :: IO [(Int, Int)]
@@ -1693,6 +1754,9 @@ main = do
         testUpdate
         testDeleteReturning
         testInsertConflict
+        testDoUpdate
+        testDoUpdateEasy
+        testDoUpdateAll
         testSelectCaseNull
       describe "range" $ do
         testRangeOverlap

--- a/src/Opaleye/Internal/HaskellDB/PrimQuery.hs
+++ b/src/Opaleye/Internal/HaskellDB/PrimQuery.hs
@@ -21,6 +21,7 @@ data Symbol = Symbol String T.Tag deriving (Read, Show)
 
 data PrimExpr   = AttrExpr  Symbol
                 | BaseTableAttrExpr Attribute
+                | ExcludedAttrExpr Attribute -- ^ @EXCLUDED.attr@ in ON CONFLICT DO UPDATE
                 | CompositeExpr     PrimExpr Attribute -- ^ Composite Type Query
                 | BinExpr   BinOp PrimExpr PrimExpr
                 | AnyExpr   BinOp PrimExpr PrimExpr -- ^ <expr> <op> ANY(<expr>)

--- a/src/Opaleye/Internal/HaskellDB/PrimQuery.hs
+++ b/src/Opaleye/Internal/HaskellDB/PrimQuery.hs
@@ -21,7 +21,12 @@ data Symbol = Symbol String T.Tag deriving (Read, Show)
 
 data PrimExpr   = AttrExpr  Symbol
                 | BaseTableAttrExpr Attribute
-                | ExcludedAttrExpr Attribute -- ^ @EXCLUDED.attr@ in ON CONFLICT DO UPDATE
+                | QualifiedAttrExpr String Attribute
+                  -- ^ @qualifier.attr@.  Used in @ON CONFLICT DO
+                  -- UPDATE@, where the proposed row is referred to as
+                  -- @excluded.attr@ and the existing row as
+                  -- @tablename.attr@.  Both must be qualified there:
+                  -- an unqualified name is ambiguous.
                 | CompositeExpr     PrimExpr Attribute -- ^ Composite Type Query
                 | BinExpr   BinOp PrimExpr PrimExpr
                 | AnyExpr   BinOp PrimExpr PrimExpr -- ^ <expr> <op> ANY(<expr>)

--- a/src/Opaleye/Internal/HaskellDB/Sql.hs
+++ b/src/Opaleye/Internal/HaskellDB/Sql.hs
@@ -73,11 +73,11 @@ data SqlUpdate  = SqlUpdate SqlTable [(SqlColumn,SqlExpr)] [SqlExpr]
 -- | Data type for SQL DELETE statements.
 data SqlDelete  = SqlDelete SqlTable [SqlExpr]
 
-data SqlConflictTarget
-  = SqlConflictColumns [SqlColumn]
-  -- ^ @ON CONFLICT (col, ...)@
-  | SqlConflictConstraint String
-  -- ^ @ON CONFLICT ON CONSTRAINT name@
+newtype SqlConflictTarget
+  = SqlConflictColumns (NEL.NonEmpty SqlExpr)
+  -- ^ @ON CONFLICT (col, (expr), ...)@.  An entry may be a plain
+  -- column, or an expression when the unique index being inferred is
+  -- an expression index.  Postgres requires at least one entry.
   deriving Show
 
 {-# DEPRECATED DoNothing "Use 'doNothing' instead.  @DoNothing@ will be removed in version 0.11" #-}

--- a/src/Opaleye/Internal/HaskellDB/Sql.hs
+++ b/src/Opaleye/Internal/HaskellDB/Sql.hs
@@ -73,10 +73,20 @@ data SqlUpdate  = SqlUpdate SqlTable [(SqlColumn,SqlExpr)] [SqlExpr]
 -- | Data type for SQL DELETE statements.
 data SqlDelete  = SqlDelete SqlTable [SqlExpr]
 
+data SqlConflictTarget
+  = SqlConflictColumns [SqlColumn]
+  -- ^ @ON CONFLICT (col, ...)@
+  | SqlConflictConstraint String
+  -- ^ @ON CONFLICT ON CONSTRAINT name@
+  deriving Show
+
 {-# DEPRECATED DoNothing "Use 'doNothing' instead.  @DoNothing@ will be removed in version 0.11" #-}
 -- It won't be removed, it will just be made internal
 data OnConflict = DoNothing
                 -- ^ @ON CONFLICT DO NOTHING@
+                | DoUpdate SqlConflictTarget [(SqlColumn, SqlExpr)]
+                -- ^ @ON CONFLICT (...) DO UPDATE SET ...@
+                deriving Show
 
 --- | Data type for SQL INSERT statements.
 data SqlInsert  = SqlInsert SqlTable [SqlColumn] (NEL.NonEmpty [SqlExpr]) (Maybe OnConflict)

--- a/src/Opaleye/Internal/HaskellDB/Sql/Default.hs
+++ b/src/Opaleye/Internal/HaskellDB/Sql/Default.hs
@@ -96,7 +96,7 @@ defaultSqlExpr gen expr =
     case expr of
       AttrExpr (Symbol a t) -> ColumnSqlExpr (SqlColumn (tagWith t a))
       BaseTableAttrExpr a -> ColumnSqlExpr (SqlColumn a)
-      ExcludedAttrExpr a -> ConstSqlExpr ("excluded.\"" ++ a ++ "\"")
+      QualifiedAttrExpr q a -> ConstSqlExpr ("\"" ++ q ++ "\".\"" ++ a ++ "\"")
       CompositeExpr e x -> CompositeSqlExpr (defaultSqlExpr gen e) x
       BinExpr op e1 e2 ->
         let leftE = sqlExpr gen e1

--- a/src/Opaleye/Internal/HaskellDB/Sql/Default.hs
+++ b/src/Opaleye/Internal/HaskellDB/Sql/Default.hs
@@ -96,6 +96,7 @@ defaultSqlExpr gen expr =
     case expr of
       AttrExpr (Symbol a t) -> ColumnSqlExpr (SqlColumn (tagWith t a))
       BaseTableAttrExpr a -> ColumnSqlExpr (SqlColumn a)
+      ExcludedAttrExpr a -> ConstSqlExpr ("excluded.\"" ++ a ++ "\"")
       CompositeExpr e x -> CompositeSqlExpr (defaultSqlExpr gen e) x
       BinExpr op e1 e2 ->
         let leftE = sqlExpr gen e1

--- a/src/Opaleye/Internal/HaskellDB/Sql/Print.hs
+++ b/src/Opaleye/Internal/HaskellDB/Sql/Print.hs
@@ -24,7 +24,7 @@ import Prelude hiding ((<>))
 import Opaleye.Internal.HaskellDB.Sql (SqlColumn(..), SqlDelete(..),
                                SqlExpr(..), SqlOrder(..), SqlInsert(..),
                                SqlUpdate(..), SqlTable(..), SqlRangeBound(..),
-                               SqlPartition(..), OnConflict(..))
+                               SqlPartition(..), OnConflict(..), SqlConflictTarget(..))
 import qualified Opaleye.Internal.HaskellDB.Sql as Sql
 
 import Data.List (intersperse)
@@ -115,9 +115,19 @@ ppDelete (SqlDelete table criteria) =
     text "DELETE FROM" <+> ppTable table $$ ppWhere criteria
 
 
+ppConflictTarget :: SqlConflictTarget -> Doc
+ppConflictTarget (SqlConflictColumns [])   = empty
+ppConflictTarget (SqlConflictColumns cols) = parens (commaH ppColumn cols)
+ppConflictTarget (SqlConflictConstraint n) = text "ON CONSTRAINT" <+> doubleQuotes (text n)
+
 ppConflictStatement :: Maybe OnConflict -> Doc
 ppConflictStatement Nothing = text ""
 ppConflictStatement (Just DoNothing) = text "ON CONFLICT DO NOTHING"
+ppConflictStatement (Just (DoUpdate target assigns)) =
+  text "ON CONFLICT" <+> ppConflictTarget target
+  <+> text "DO UPDATE SET"
+  <+> commaV ppAssign assigns
+  where ppAssign (c, e) = ppColumn c <+> equals <+> ppSqlExpr e
 
 ppInsert :: SqlInsert -> Doc
 ppInsert (SqlInsert table names values onConflict)

--- a/src/Opaleye/Internal/HaskellDB/Sql/Print.hs
+++ b/src/Opaleye/Internal/HaskellDB/Sql/Print.hs
@@ -116,9 +116,14 @@ ppDelete (SqlDelete table criteria) =
 
 
 ppConflictTarget :: SqlConflictTarget -> Doc
-ppConflictTarget (SqlConflictColumns [])   = empty
-ppConflictTarget (SqlConflictColumns cols) = parens (commaH ppColumn cols)
-ppConflictTarget (SqlConflictConstraint n) = text "ON CONSTRAINT" <+> doubleQuotes (text n)
+ppConflictTarget (SqlConflictColumns es) =
+  parens (commaH ppConflictTargetEntry (NEL.toList es))
+  -- A plain column must be printed bare.  Postgres only matches a
+  -- parenthesised entry against an expression index, so wrapping a
+  -- column reference in parens would stop it inferring an ordinary
+  -- index on that column.
+  where ppConflictTargetEntry (ColumnSqlExpr c) = ppColumn c
+        ppConflictTargetEntry e                 = parens (ppSqlExpr e)
 
 ppConflictStatement :: Maybe OnConflict -> Doc
 ppConflictStatement Nothing = text ""

--- a/src/Opaleye/Internal/Manipulation.hs
+++ b/src/Opaleye/Internal/Manipulation.hs
@@ -4,7 +4,10 @@ module Opaleye.Internal.Manipulation where
 
 import qualified Control.Applicative as A
 
+import qualified Data.Functor.Identity as I
+
 import           Opaleye.Internal.Column (Field_(Column), Field)
+import qualified Opaleye.Internal.HaskellDB.PrimQuery as HPQ
 import qualified Opaleye.Internal.HaskellDB.Sql  as HSql
 import qualified Opaleye.Internal.HaskellDB.Sql.Default  as SD
 import qualified Opaleye.Internal.HaskellDB.Sql.Generate as SG
@@ -76,6 +79,28 @@ arrangeInsertManySql :: T.Table columnsW columnsR
                      -> String
 arrangeInsertManySql =
   show . HPrint.ppInsert .:. arrangeInsertMany
+
+arrangeDoUpdate
+  :: U.Unpackspec conflictCols conflictCols
+  -> U.Unpackspec columnsR columnsR
+  -> T.Table columnsW columnsR
+  -> (columnsR -> conflictCols)
+  -> (columnsR -> columnsW)
+  -> HSql.OnConflict
+arrangeDoUpdate unpackConflict unpackR table conflictTarget updateFn =
+  HSql.DoUpdate (HSql.SqlConflictColumns conflictSqlCols) sqlAssigns
+  where
+    TI.View columnsR = TI.tableColumnsView (TI.tableColumns table)
+    conflictPEs = U.collectPEs unpackConflict (conflictTarget columnsR)
+    conflictSqlCols = map peToSqlColumn conflictPEs
+    peToSqlColumn (HPQ.BaseTableAttrExpr a) = HSql.SqlColumn a
+    peToSqlColumn pe = error ("arrangeDoUpdate: conflict target must be a plain table column, got: " ++ show pe)
+    excludedRow = I.runIdentity $ U.runUnpackspec unpackR toExcludedPE columnsR
+    toExcludedPE (HPQ.BaseTableAttrExpr a) = I.Identity (HPQ.ExcludedAttrExpr a)
+    toExcludedPE pe = I.Identity pe
+    writer = TI.tableColumnsWriter (TI.tableColumns table)
+    writerAssigns = TI.runWriter writer (updateFn excludedRow)
+    sqlAssigns = [(HSql.SqlColumn col, Sql.sqlExpr pe) | (pe, col) <- writerAssigns]
 
 runInsertManyReturningExplicit
   :: RS.FromFields columnsReturned haskells

--- a/src/Opaleye/Internal/Manipulation.hs
+++ b/src/Opaleye/Internal/Manipulation.hs
@@ -85,7 +85,7 @@ arrangeDoUpdate
   -> U.Unpackspec columnsR columnsR
   -> T.Table columnsW columnsR
   -> (columnsR -> conflictCols)
-  -> (columnsR -> columnsW)
+  -> (columnsR -> columnsR -> columnsW)
   -> HSql.OnConflict
 arrangeDoUpdate unpackConflict unpackR table conflictTarget updateFn =
   HSql.DoUpdate (HSql.SqlConflictColumns conflictSqlCols) sqlAssigns
@@ -95,11 +95,17 @@ arrangeDoUpdate unpackConflict unpackR table conflictTarget updateFn =
     conflictSqlCols = map peToSqlColumn conflictPEs
     peToSqlColumn (HPQ.BaseTableAttrExpr a) = HSql.SqlColumn a
     peToSqlColumn pe = error ("arrangeDoUpdate: conflict target must be a plain table column, got: " ++ show pe)
-    excludedRow = I.runIdentity $ U.runUnpackspec unpackR toExcludedPE columnsR
-    toExcludedPE (HPQ.BaseTableAttrExpr a) = I.Identity (HPQ.ExcludedAttrExpr a)
-    toExcludedPE pe = I.Identity pe
+    -- Both rows have to be qualified on the right hand side of DO
+    -- UPDATE SET: the existing row and excluded are both in scope
+    -- there, so an unqualified column name is ambiguous.  The existing
+    -- row is qualified by the bare table name, without the schema.
+    qualifyRow q = I.runIdentity . U.runUnpackspec unpackR (toQualifiedPE q)
+    toQualifiedPE q (HPQ.BaseTableAttrExpr a) = I.Identity (HPQ.QualifiedAttrExpr q a)
+    toQualifiedPE _ pe = I.Identity pe
+    existingRow = qualifyRow (PQ.tiTableName (TI.tableIdentifier table)) columnsR
+    excludedRow = qualifyRow "excluded" columnsR
     writer = TI.tableColumnsWriter (TI.tableColumns table)
-    writerAssigns = TI.runWriter writer (updateFn excludedRow)
+    writerAssigns = TI.runWriter writer (updateFn existingRow excludedRow)
     sqlAssigns = [(HSql.SqlColumn col, Sql.sqlExpr pe) | (pe, col) <- writerAssigns]
 
 runInsertManyReturningExplicit

--- a/src/Opaleye/Internal/Manipulation.hs
+++ b/src/Opaleye/Internal/Manipulation.hs
@@ -88,13 +88,18 @@ arrangeDoUpdate
   -> (columnsR -> columnsR -> columnsW)
   -> HSql.OnConflict
 arrangeDoUpdate unpackConflict unpackR table conflictTarget updateFn =
-  HSql.DoUpdate (HSql.SqlConflictColumns conflictSqlCols) sqlAssigns
+  HSql.DoUpdate (HSql.SqlConflictColumns conflictSqlExprs) sqlAssigns
   where
     TI.View columnsR = TI.tableColumnsView (TI.tableColumns table)
     conflictPEs = U.collectPEs unpackConflict (conflictTarget columnsR)
-    conflictSqlCols = map peToSqlColumn conflictPEs
-    peToSqlColumn (HPQ.BaseTableAttrExpr a) = HSql.SqlColumn a
-    peToSqlColumn pe = error ("arrangeDoUpdate: conflict target must be a plain table column, got: " ++ show pe)
+    -- Postgres has nothing to infer a unique index from if the
+    -- conflict target is empty, and rejects the statement, so fail
+    -- here with a message that says which function is at fault.
+    conflictSqlExprs = case NEL.nonEmpty (map Sql.sqlExpr conflictPEs) of
+      Just nel -> nel
+      Nothing  -> error "Opaleye: the conflict target of doUpdate, \
+                        \doUpdateEasy or doUpdateAll must contain at \
+                        \least one column"
     -- Both rows have to be qualified on the right hand side of DO
     -- UPDATE SET: the existing row and excluded are both in scope
     -- there, so an unqualified column name is ambiguous.  The existing

--- a/src/Opaleye/Manipulation.hs
+++ b/src/Opaleye/Manipulation.hs
@@ -37,11 +37,11 @@ module Opaleye.Manipulation (-- * Insert
                              rReturningI,
                              rReturningExplicit,
                              -- * On conflict
-                             -- | Currently 'doNothing' is the
-                             -- only conflict action supported by
-                             -- Opaleye.
                              HSql.OnConflict,
                              doNothing,
+                             doUpdate,
+                             doUpdateEasy,
+                             doUpdateAll,
                              -- * Deprecated
                              runInsert_,
                              runUpdate_,
@@ -63,6 +63,7 @@ import           Opaleye.Internal.Helpers ((.:.))
 import           Opaleye.Internal.Inferrable (Inferrable, runInferrable)
 import           Opaleye.Internal.Manipulation (Updater(Updater))
 import qualified Opaleye.Internal.Manipulation as MI
+import qualified Opaleye.Internal.Unpackspec as U
 import           Opaleye.SqlTypes (SqlBool)
 
 import qualified Opaleye.Internal.HaskellDB.Sql as HSql
@@ -256,5 +257,104 @@ runUpdateReturningExplicit qr conn t update cond r =
         parser = IRQ.prepareRowParser qr (r v)
         TI.View v = TI.tableColumnsView (TI.tableColumns t)
 
+-- | Skip the conflicting row, leaving the existing row unchanged.
+--
+-- @
+-- iOnConflict = Just doNothing
+-- @
 doNothing :: HSql.OnConflict
 doNothing = HSql.DoNothing
+
+-- | Replace every column with the corresponding @EXCLUDED@ value on
+-- conflict.  This is the most common upsert pattern.  Equivalent to
+-- @'doUpdateEasy' table conflictTarget id@.
+--
+-- @
+-- -- data Stock' a b = Stock { sku :: a, quantity :: b }
+-- -- \$(makeAdaptorAndInstance \"pStock\" \'\'Stock\')
+-- -- type Stock = Stock' (Field SqlText) (Field SqlInt4)
+-- --
+-- -- stockTable :: Table Stock Stock
+-- -- stockTable = table "stock" $ pStock Stock
+-- --   { sku      = requiredTableField "sku"
+-- --   , quantity = requiredTableField "quantity"
+-- --   }
+-- -- On conflict: both sku and quantity are replaced with the new row's values.
+--
+-- iOnConflict = Just (doUpdateAll stockTable sku)
+-- @
+doUpdateAll :: ( D.Default U.Unpackspec conflictCols conflictCols
+               , D.Default U.Unpackspec fieldsR fieldsR
+               , D.Default MI.Updater fieldsR fieldsW
+               )
+            => T.Table fieldsW fieldsR
+            -> (fieldsR -> conflictCols)
+            -- ^ Columns forming the conflict target
+            -> HSql.OnConflict
+doUpdateAll table conflictTarget = doUpdateEasy table conflictTarget id
+
+-- | Build an @ON CONFLICT (...) DO UPDATE SET@ conflict action.
+-- The update function receives the @EXCLUDED@ pseudo-row and returns
+-- the new column values.  Optional columns (created with
+-- 'Opaleye.Table.optionalTableField') must be wrapped in 'Just';
+-- see 'doUpdateEasy' to avoid this.
+--
+-- @
+-- -- data Stock' a b c = Stock { sku :: a, quantity :: b, reserved :: c }
+-- -- \$(makeAdaptorAndInstance \"pStock\" \'\'Stock\')
+-- -- type Stock  = Stock' (Field SqlText) (Field SqlInt4) (Field SqlInt4)
+-- -- type StockW = Stock' (Field SqlText) (Maybe (Field SqlInt4)) (Maybe (Field SqlInt4))
+-- --
+-- -- stockTable :: Table StockW Stock
+-- -- stockTable = table "stock" $ pStock Stock
+-- --   { sku      = requiredTableField "sku"
+-- --   , quantity = optionalTableField "quantity"
+-- --   , reserved = optionalTableField "reserved"
+-- --   }
+-- -- On conflict: sku unchanged, quantity updated, reserved reset to DEFAULT.
+--
+-- iOnConflict = Just (doUpdate stockTable sku
+--     (\\excl -> Stock
+--         { sku      = sku excl       -- unchanged (equals conflict key)
+--         , quantity = Just (quantity excl)  -- updated (Just required)
+--         , reserved = Nothing               -- reset to column DEFAULT
+--         }))
+-- @
+doUpdate :: ( D.Default U.Unpackspec conflictCols conflictCols
+            , D.Default U.Unpackspec fieldsR fieldsR
+            )
+         => T.Table fieldsW fieldsR
+         -> (fieldsR -> conflictCols)
+         -- ^ Columns forming the conflict target
+         -> (fieldsR -> fieldsW)
+         -- ^ Update function; receives the @EXCLUDED@ pseudo-row
+         -> HSql.OnConflict
+doUpdate = MI.arrangeDoUpdate D.def D.def
+
+-- | Like 'doUpdate' but optional columns do not need to be wrapped in
+-- 'Just'.
+--
+-- @
+-- -- (same stockTable as 'doUpdate' above)
+-- -- On conflict: sku unchanged, quantity updated, reserved reset to DEFAULT.
+-- -- No Just wrapping needed — compare with 'doUpdate'.
+--
+-- iOnConflict = Just (doUpdateEasy stockTable sku
+--     (\\excl -> excl
+--         { quantity = quantity excl  -- updated (no Just needed)
+--         , reserved = reserved excl  -- updated (no Just needed)
+--         }))
+-- @
+doUpdateEasy :: ( D.Default U.Unpackspec conflictCols conflictCols
+                , D.Default U.Unpackspec fieldsR fieldsR
+                , D.Default MI.Updater fieldsR fieldsW
+                )
+             => T.Table fieldsW fieldsR
+             -> (fieldsR -> conflictCols)
+             -- ^ Columns forming the conflict target
+             -> (fieldsR -> fieldsR)
+             -- ^ Update function; receives the @EXCLUDED@ pseudo-row
+             -> HSql.OnConflict
+doUpdateEasy table conflictTarget updateFn =
+  MI.arrangeDoUpdate D.def D.def table conflictTarget (u' . updateFn)
+  where Updater u' = D.def

--- a/src/Opaleye/Manipulation.hs
+++ b/src/Opaleye/Manipulation.hs
@@ -267,7 +267,7 @@ doNothing = HSql.DoNothing
 
 -- | Replace every column with the corresponding @EXCLUDED@ value on
 -- conflict.  This is the most common upsert pattern.  Equivalent to
--- @'doUpdateEasy' table conflictTarget id@.
+-- @'doUpdateEasy' table conflictTarget (\\_ excluded -> excluded)@.
 --
 -- @
 -- -- data Stock' a b = Stock { sku :: a, quantity :: b }
@@ -291,13 +291,15 @@ doUpdateAll :: ( D.Default U.Unpackspec conflictCols conflictCols
             -> (fieldsR -> conflictCols)
             -- ^ Columns forming the conflict target
             -> HSql.OnConflict
-doUpdateAll table conflictTarget = doUpdateEasy table conflictTarget id
+doUpdateAll table conflictTarget =
+  doUpdateEasy table conflictTarget (\_ excluded -> excluded)
 
--- | Build an @ON CONFLICT (...) DO UPDATE SET@ conflict action.
--- The update function receives the @EXCLUDED@ pseudo-row and returns
--- the new column values.  Optional columns (created with
--- 'Opaleye.Table.optionalTableField') must be wrapped in 'Just';
--- see 'doUpdateEasy' to avoid this.
+-- | Build an @ON CONFLICT (...) DO UPDATE SET@ conflict action.  The
+-- update function receives the existing row and the @EXCLUDED@
+-- pseudo-row (the row that was proposed for insertion) and returns the
+-- new column values.  Optional columns (created with
+-- 'Opaleye.Table.optionalTableField') must be wrapped in 'Just'; see
+-- 'doUpdateEasy' to avoid this.
 --
 -- @
 -- -- data Stock' a b c = Stock { sku :: a, quantity :: b, reserved :: c }
@@ -311,23 +313,28 @@ doUpdateAll table conflictTarget = doUpdateEasy table conflictTarget id
 -- --   , quantity = optionalTableField "quantity"
 -- --   , reserved = optionalTableField "reserved"
 -- --   }
--- -- On conflict: sku unchanged, quantity updated, reserved reset to DEFAULT.
+-- -- On conflict: sku unchanged, quantity accumulated, reserved reset to DEFAULT.
 --
 -- iOnConflict = Just (doUpdate stockTable sku
---     (\\excl -> Stock
---         { sku      = sku excl       -- unchanged (equals conflict key)
---         , quantity = Just (quantity excl)  -- updated (Just required)
---         , reserved = Nothing               -- reset to column DEFAULT
+--     (\\existing excluded -> Stock
+--         { sku      = sku excluded  -- unchanged (equals conflict key)
+--         , quantity = Just (quantity existing + quantity excluded)
+--         , reserved = Nothing       -- reset to column DEFAULT
 --         }))
 -- @
+--
+-- To leave a column untouched, set it to its value in the existing row,
+-- e.g. @reserved = Just (reserved existing)@.  Note that 'Nothing' means
+-- @DEFAULT@, not \"leave unchanged\".
 doUpdate :: ( D.Default U.Unpackspec conflictCols conflictCols
             , D.Default U.Unpackspec fieldsR fieldsR
             )
          => T.Table fieldsW fieldsR
          -> (fieldsR -> conflictCols)
          -- ^ Columns forming the conflict target
-         -> (fieldsR -> fieldsW)
-         -- ^ Update function; receives the @EXCLUDED@ pseudo-row
+         -> (fieldsR -> fieldsR -> fieldsW)
+         -- ^ Update function; receives the existing row and the
+         -- @EXCLUDED@ pseudo-row
          -> HSql.OnConflict
 doUpdate = MI.arrangeDoUpdate D.def D.def
 
@@ -336,15 +343,18 @@ doUpdate = MI.arrangeDoUpdate D.def D.def
 --
 -- @
 -- -- (same stockTable as 'doUpdate' above)
--- -- On conflict: sku unchanged, quantity updated, reserved reset to DEFAULT.
+-- -- On conflict: sku unchanged, quantity accumulated, reserved overwritten.
 -- -- No Just wrapping needed — compare with 'doUpdate'.
 --
 -- iOnConflict = Just (doUpdateEasy stockTable sku
---     (\\excl -> excl
---         { quantity = quantity excl  -- updated (no Just needed)
---         , reserved = reserved excl  -- updated (no Just needed)
+--     (\\existing excluded -> existing
+--         { quantity = quantity existing + quantity excluded
+--         , reserved = reserved excluded
 --         }))
 -- @
+--
+-- Updating the existing row with record syntax, as above, means any
+-- column you do not mention keeps its existing value.
 doUpdateEasy :: ( D.Default U.Unpackspec conflictCols conflictCols
                 , D.Default U.Unpackspec fieldsR fieldsR
                 , D.Default MI.Updater fieldsR fieldsW
@@ -352,9 +362,11 @@ doUpdateEasy :: ( D.Default U.Unpackspec conflictCols conflictCols
              => T.Table fieldsW fieldsR
              -> (fieldsR -> conflictCols)
              -- ^ Columns forming the conflict target
-             -> (fieldsR -> fieldsR)
-             -- ^ Update function; receives the @EXCLUDED@ pseudo-row
+             -> (fieldsR -> fieldsR -> fieldsR)
+             -- ^ Update function; receives the existing row and the
+             -- @EXCLUDED@ pseudo-row
              -> HSql.OnConflict
 doUpdateEasy table conflictTarget updateFn =
-  MI.arrangeDoUpdate D.def D.def table conflictTarget (u' . updateFn)
+  MI.arrangeDoUpdate D.def D.def table conflictTarget
+    (\existing excluded -> u' (updateFn existing excluded))
   where Updater u' = D.def


### PR DESCRIPTION
## Summary

- Extends `OnConflict` with a `DoUpdate` variant carrying a conflict target and a list of `(column, expr)` assignments
- Adds `ExcludedAttrExpr` to `PrimExpr` so the `EXCLUDED` pseudo-table renders correctly in SQL
- Exposes three smart constructors in `Opaleye.Manipulation`:
  - `doUpdate` — update function in write-type space; optional columns need explicit `Just`
  - `doUpdateEasy` — update function in read-type space; no `Just` wrapping needed
  - `doUpdateAll` — replaces every column with the corresponding `EXCLUDED` value (most common upsert pattern)
- Adds tests for all three variants